### PR TITLE
NO-JIRA: Update rebaseLabel name in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
 				"automerge": true
 			}
 		],
-		"rebaseLabel": "rebase",
+		"rebaseLabel": "needs-rebase",
 		"rebaseWhen": "auto"
 	}
 }


### PR DESCRIPTION
We need write access to add labels to PR, hence updating the rebaseLabel in renovate.json to use the `needs-rebase` added by the prow/tide.