### PR TITLE
NO-JIRA: Update renovate config with new package managers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ verify-containerfiles:
 
 ## verify the changes are working as expected.
 .PHONY: verify
-verify: verify-shell-scripts verify-containerfiles build-images
+verify: verify-shell-scripts verify-containerfiles validate-renovate-config build-images
 
 ## update all required contents.
 .PHONY: update
@@ -208,3 +208,9 @@ $(CERT_MANAGER_OPERATOR_BUNDLE_IMAGE):$(IMAGE_VERSION) \
 $(CATALOG_IMAGE):$(IMAGE_VERSION)
 
 	rm -r $(TOOL_BIN_DIR)
+
+## validate renovate config.
+.PHONY: validate-renovate-config
+validate-renovate-config:
+	./hack/renovate-config-validator.sh
+

--- a/hack/renovate-config-validator.sh
+++ b/hack/renovate-config-validator.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+validate_config()
+{
+	if ! podman run -e "LOG_LEVEL=debug" --rm -v "./renovate.json:/tmp/validate/renovate.json" ghcr.io/renovatebot/renovate \
+		renovate-config-validator --strict /tmp/validate/renovate.json; then
+		exit 1
+	fi
+}
+
+##############################################
+###############  MAIN  #######################
+##############################################
+
+validate_config
+
+exit 0

--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,16 @@
 	"extends": [
 		"https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json?raw=true"
 	],
+	"assigneesFromCodeOwners": true,
+	"automergeStrategy": "auto",
+	"automergeType": "pr",
+	"commitMessagePrefix": "NO-JIRA: ",
+	"ignoreTests": false,
+	"rebaseLabel": "needs-rebase",
+	"rebaseWhen": "behind-base-branch",
+	"recreateWhen": "always",
 	"tekton": {
-		"assigneesFromCodeOwners": true,
-		"automergeStrategy": "auto",
-		"automergeType": "pr",
-		"commitMessagePrefix": "NO-JIRA: ",
 		"enabled": true,
-		"ignoreTests": false,
 		"packageRules": [
 			{
 				"matchUpdateTypes": [
@@ -20,8 +23,18 @@
 				],
 				"automerge": true
 			}
-		],
-		"rebaseLabel": "needs-rebase",
-		"rebaseWhen": "auto"
+		]
+	},
+	"dockerfile": {
+		"enabled": true,
+		"packageRules": [
+			{
+				"matchFileNames": ["Containerfile.*"],
+				"automerge": true
+			}
+		]
+	},
+	"git-submodules": {
+		"enabled": false
 	}
 }


### PR DESCRIPTION
PR contains below changes
- Updates renovate config with new package managers
  - dockerfile
  - git-submodules
- New Makefile target for validating renovate config changes.
- New script to validate renovate config.