### PR TITLE
NO-JIRA: Customize cert-manager-operator-bundle tekton pac to comply with EC policy

### DIFF
--- a/.tekton/cert-manager-operator-bundle-1-15-pull-request.yaml
+++ b/.tekton/cert-manager-operator-bundle-1-15-pull-request.yaml
@@ -2,13 +2,17 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    build.appstudio.openshift.io/request: "configure-pac"
     build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.15"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.15" &&
+      (".tekton/cert-manager-operator-bundle-1-15-pull-request.yaml".pathChanged() ||
+      "Containerfile.cert-manager-operator.bundle".pathChanged() || "hack/bundle/render_templates.sh".pathChanged() ||
+      "cert-manager-operator/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cert-manager-operator-1-15
@@ -30,6 +34,13 @@ spec:
     value: Containerfile.cert-manager-operator.bundle
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "RELEASE_VERSION=v1.15.0"
+    - "COMMIT_SHA={{revision}}"
+    - "SOURCE_URL={{source_url}}"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -79,7 +90,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -91,11 +102,11 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
-    - default: "false"
+    - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string

--- a/.tekton/cert-manager-operator-bundle-1-15-push.yaml
+++ b/.tekton/cert-manager-operator-bundle-1-15-push.yaml
@@ -2,12 +2,16 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    build.appstudio.openshift.io/request: "configure-pac"
     build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.15"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.15" &&
+      (".tekton/cert-manager-operator-bundle-1-15-push.yaml".pathChanged() ||
+      "Containerfile.cert-manager-operator.bundle".pathChanged() || "hack/bundle/render_templates.sh".pathChanged() ||
+      "cert-manager-operator/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cert-manager-operator-1-15
@@ -27,6 +31,13 @@ spec:
     value: Containerfile.cert-manager-operator.bundle
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "RELEASE_VERSION=v1.15.0"
+    - "COMMIT_SHA={{revision}}"
+    - "SOURCE_URL={{source_url}}"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -76,7 +87,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -88,11 +99,11 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
-    - default: "false"
+    - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string


### PR DESCRIPTION
PR contains below changes
- CEL validations to avoid redundant builds
- Adds build args
- Enables hermetic build, source build and OCI index