### PR TITLE
CM-358: [bump/v1.15.4] update operand tags

### DIFF
--- a/.tekton/jetstack-cert-manager-1-15-pull-request.yaml
+++ b/.tekton/jetstack-cert-manager-1-15-pull-request.yaml
@@ -35,7 +35,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - "RELEASE_VERSION=v1.15.2"
+    - "RELEASE_VERSION=v1.15.4"
     - "COMMIT_SHA={{revision}}"
     - "SOURCE_URL={{source_url}}"
   - name: prefetch-input

--- a/.tekton/jetstack-cert-manager-1-15-push.yaml
+++ b/.tekton/jetstack-cert-manager-1-15-push.yaml
@@ -32,7 +32,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - "RELEASE_VERSION=v1.15.2"
+    - "RELEASE_VERSION=v1.15.4"
     - "COMMIT_SHA={{revision}}"
     - "SOURCE_URL={{source_url}}"
   - name: prefetch-input

--- a/.tekton/jetstack-cert-manager-acmesolver-1-15-pull-request.yaml
+++ b/.tekton/jetstack-cert-manager-acmesolver-1-15-pull-request.yaml
@@ -35,7 +35,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - "RELEASE_VERSION=v1.15.2"
+    - "RELEASE_VERSION=v1.15.4"
     - "COMMIT_SHA={{revision}}"
     - "SOURCE_URL={{source_url}}"
   - name: prefetch-input

--- a/.tekton/jetstack-cert-manager-acmesolver-1-15-push.yaml
+++ b/.tekton/jetstack-cert-manager-acmesolver-1-15-push.yaml
@@ -32,7 +32,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - "RELEASE_VERSION=v1.15.2"
+    - "RELEASE_VERSION=v1.15.4"
     - "COMMIT_SHA={{revision}}"
     - "SOURCE_URL={{source_url}}"
   - name: prefetch-input

--- a/catalog/openshift-cert-manager-operator/bundle.yaml
+++ b/catalog/openshift-cert-manager-operator/bundle.yaml
@@ -308,7 +308,7 @@ properties:
         name: orders.acme.cert-manager.io
         version: v1
     description: |
-      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.15.2](https://github.com/cert-manager/cert-manager/tree/v1.15.2), which automates certificate management.
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.15.4](https://github.com/cert-manager/cert-manager/tree/v1.15.4), which automates certificate management.
       For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
     displayName: cert-manager Operator for Red Hat OpenShift
     installModes:


### PR DESCRIPTION
react to changes in https://github.com/openshift/cert-manager-operator/pull/232, update upstream tags.