### PR TITLE
NO-JIRA: konflux team fix for false sbom_cyclonedx EC violation

### DIFF
--- a/.tekton/fbc-build-pipeline.yaml
+++ b/.tekton/fbc-build-pipeline.yaml
@@ -214,7 +214,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
           - name: kind
             value: task
         resolver: bundles

--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -214,7 +214,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
           - name: kind
             value: task
         resolver: bundles

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -198,7 +198,7 @@ spec:
           - name: name
             value: buildah-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.3@sha256:d35ff2504c0f58fd71879c917a1c66d817143cd8586b4bbd6cff0f3f91e5d040
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.3@sha256:b1cdafdac20b33cb6ccbad64fa91abc0aa673f1bdfcf95abd5cf230e0c4ea2b4
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
EC policy validation is failing with `CycloneDX SBOM` invalid error, which is happening because of CycloneDX version bump from 1.5 to 1.6.

Updating the konflux task image references, since automated update will happen later this week, and this s required for 1.15 release.