### PR TITLE
CM-464: Adds istio-csr image ref in bundle CSV

### DIFF
--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -12,7 +12,7 @@ spec:
     - name: show-sbom
       params:
         - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
           - name: name
@@ -102,10 +102,10 @@ spec:
   results:
     - description: ""
       name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
+      value: $(tasks.build-container.results.IMAGE_URL)
     - description: ""
       name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
     - description: ""
       name: CHAINS-GIT_URL
       value: $(tasks.clone-repository.results.url)

--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -12,7 +12,8 @@ ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-ope
     CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5be6fd3c5ad3128b2b32438e8d1c25f5261deba1cdb65f2c87344009948da7a8 \
     CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5be6fd3c5ad3128b2b32438e8d1c25f5261deba1cdb65f2c87344009948da7a8 \
     CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5be6fd3c5ad3128b2b32438e8d1c25f5261deba1cdb65f2c87344009948da7a8 \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:32ca590f38af6c5d367609586869375087f863b318ce7c302aecab537f103035
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:32ca590f38af6c5d367609586869375087f863b318ce7c302aecab537f103035 \
+    CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:8c8404212d977f69b2b49f81dcb82fd08199e926c24a6b9e45259556ce1ad5e9
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime
@@ -26,7 +27,8 @@ RUN ./render_templates.sh /manifests /metadata \
     "${CERT_MANAGER_WEBHOOK_IMAGE}" \
     "${CERT_MANAGER_CA_INJECTOR_IMAGE}" \
     "${CERT_MANAGER_CONTROLLER_IMAGE}" \
-    "${CERT_MANAGER_ACMESOLVER_IMAGE}"
+    "${CERT_MANAGER_ACMESOLVER_IMAGE}" \
+    "${CERT_MANAGER_ISTIOCSR_IMAGE}"
 
 FROM registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
 

--- a/hack/bundle/render_templates.sh
+++ b/hack/bundle/render_templates.sh
@@ -9,6 +9,7 @@ declare CERT_MANAGER_WEBHOOK_IMAGE
 declare CERT_MANAGER_CA_INJECTOR_IMAGE
 declare CERT_MANAGER_CONTROLLER_IMAGE
 declare CERT_MANAGER_ACMESOLVER_IMAGE
+declare CERT_MANAGER_ISTIOCSR_IMAGE
 
 CSV_FILE_NAME="cert-manager-operator.clusterserviceversion.yaml"
 ANNOTATIONS_FILE_NAME="annotations.yaml"
@@ -26,6 +27,7 @@ update_csv_manifest()
 	sed -i "s#quay.io/jetstack/cert-manager-controller.*#${CERT_MANAGER_CONTROLLER_IMAGE}#g" "${CSV_FILE}"
 	sed -i "s#quay.io/jetstack/cert-manager-cainjector.*#${CERT_MANAGER_CA_INJECTOR_IMAGE}#g" "${CSV_FILE}"
 	sed -i "s#quay.io/jetstack/cert-manager-acmesolver.*#${CERT_MANAGER_ACMESOLVER_IMAGE}#g" "${CSV_FILE}"
+	sed -i "s#quay.io/jetstack/cert-manager-istio-csr.*#${CERT_MANAGER_ISTIOCSR_IMAGE}#g" "${CSV_FILE}"
 
 	## replace cert-manager-operator image
 	sed -i "s#openshift.io/cert-manager-operator.*#${CERT_MANAGER_OPERATOR_IMAGE}#g" "${CSV_FILE}"
@@ -55,6 +57,7 @@ usage()
 		'"<CERT_MANAGER_CA_INJECTOR_IMAGE>"' \
 		'"<CERT_MANAGER_CONTROLLER_IMAGE>"' \
 		'"<CERT_MANAGER_ACMESOLVER_IMAGE>"' \
+		'"<CERT_MANAGER_ISTIOCSR_IMAGE>"'
 	exit 1
 }
 
@@ -73,6 +76,7 @@ CERT_MANAGER_WEBHOOK_IMAGE=$4
 CERT_MANAGER_CA_INJECTOR_IMAGE=$5
 CERT_MANAGER_CONTROLLER_IMAGE=$6
 CERT_MANAGER_ACMESOLVER_IMAGE=$7
+CERT_MANAGER_ISTIOCSR_IMAGE=$8
 
 echo "[$(date)] -- INFO  -- $*"
 


### PR DESCRIPTION
PR has below changes:

- Updates bundle Containerfile to add istio-csr image ref, which will be used to replace the default image in bundle CSV manifest during build.
- Updates template CSV manifest rendering script to replace istio-csr image in the manifest, which is required for deploying istio-csr with the required image.