### PR TITLE
CM-464: Updates 4.18, 4.19 catalogs with latest 1.15.1 bundle

### DIFF
--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.15.1.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.15.1.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fecf87a0a515a7653d5e46c8185c7dbc1d2b5d9289177d3ca48544517120f04
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:6c32738629b15aa5b3f9e15f4d4c722cf16eb58e44fd3429c25ae10845e51df4
 name: cert-manager-operator.v1.15.1
 package: openshift-cert-manager-operator
 properties:
@@ -287,7 +287,7 @@ properties:
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
       containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:955e11816137fdfb75e89c2db941250b06e1556352ea45550b6d6b83be62b62d
-      createdAt: 2025-02-26T06:31:33
+      createdAt: 2025-02-27T09:26:47
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -380,9 +380,9 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:8c8404212d977f69b2b49f81dcb82fd08199e926c24a6b9e45259556ce1ad5e9
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:ae9a6842139b42b98364480b4a9da0261663167fd95d953e7c0b1ae4320e14b0
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fecf87a0a515a7653d5e46c8185c7dbc1d2b5d9289177d3ca48544517120f04
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:6c32738629b15aa5b3f9e15f4d4c722cf16eb58e44fd3429c25ae10845e51df4
   name: ""
 - image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:955e11816137fdfb75e89c2db941250b06e1556352ea45550b6d6b83be62b62d
   name: ""

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.15.1.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.15.1.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fecf87a0a515a7653d5e46c8185c7dbc1d2b5d9289177d3ca48544517120f04
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:6c32738629b15aa5b3f9e15f4d4c722cf16eb58e44fd3429c25ae10845e51df4
 name: cert-manager-operator.v1.15.1
 package: openshift-cert-manager-operator
 properties:
@@ -287,7 +287,7 @@ properties:
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
       containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:955e11816137fdfb75e89c2db941250b06e1556352ea45550b6d6b83be62b62d
-      createdAt: 2025-02-26T06:31:33
+      createdAt: 2025-02-27T09:26:47
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -380,9 +380,9 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:8c8404212d977f69b2b49f81dcb82fd08199e926c24a6b9e45259556ce1ad5e9
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:ae9a6842139b42b98364480b4a9da0261663167fd95d953e7c0b1ae4320e14b0
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fecf87a0a515a7653d5e46c8185c7dbc1d2b5d9289177d3ca48544517120f04
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:6c32738629b15aa5b3f9e15f4d4c722cf16eb58e44fd3429c25ae10845e51df4
   name: ""
 - image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:955e11816137fdfb75e89c2db941250b06e1556352ea45550b6d6b83be62b62d
   name: ""


### PR DESCRIPTION
PR is for updating 4.18 and 4.19 operator catalog with latest 1.15.1 bundle.