### PR TITLE
CM-464: Remove ecosystem-cert-preflight-checks task from tekton pipeline for bundle

### DIFF
--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -291,26 +291,6 @@ spec:
           value: "$(tasks.build-container.results.IMAGE_DIGEST)"
         - name: image-url
           value: "$(tasks.build-container.results.IMAGE_URL)"
-    - name: ecosystem-cert-preflight-checks
-      taskRef:
-        params:
-          - name: name
-            value: ecosystem-cert-preflight-checks
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: "$(params.skip-checks)"
-          operator: in
-          values:
-            - 'false'
-      runAfter:
-        - build-container
-      params:
-        - name: image-url
-          value: "$(tasks.build-container.results.IMAGE_URL)"
     - name: sast-snyk-check
       taskRef:
         params:


### PR DESCRIPTION
`ecosystem-cert-preflight-checks` are skipped for operator bundles, and the EC policy validation fails when any task is skipped. And as per the [suggestion](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1741013604727269?thread_ts=1740901637.372379&cid=C04PZ7H0VA8) from konflux team, removing non-essential task from the pipeline.

Task logs:
```
step-set-skip-for-bundles
{"result":"SKIPPED","timestamp":"2025-03-12T13:54:51+00:00","note":"This ecosystem check is not executed for operatorbundles.","namespace":"default","successes":0,"failures":0,"warnings":0}
```

EC policy verification logs:
```
      "violations": [
        {
          "msg": "The Task \"ecosystem-cert-preflight-checks\" from the build Pipeline reports a test was skipped",
          "metadata": {
            "code": "test.no_skipped_tests",
            "collections": [
              "redhat"
            ],
            "depends_on": [
              "test.test_data_found"
            ],
            "description": "Produce a violation if any tests have their result set to \"SKIPPED\". A skipped result means a pre-requirement for executing the test was not met, e.g. a license key for executing a scanner was not provided. The result type is configurable by the \"skipped_tests_results\" key in the rule data. To exclude this rule add \"test.no_skipped_tests:ecosystem-cert-preflight-checks\" to the `exclude` section of the policy configuration.",
            "solution": "There is a test that was skipped. Make sure that each task with a result named 'TEST_OUTPUT' was not skipped. You can find which test was skipped by examining the 'result' key in the 'TEST_OUTPUT'. More information about the test should be available in the logs for the build Pipeline.",
            "term": "ecosystem-cert-preflight-checks",
            "title": "No tests were skipped"
          }
        }
      ]
```