### PR TITLE
[release-1.14] CM-460: Use promoted production images in Containerfile.bundle

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -9,11 +9,11 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
 
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5c593bfd70309f87cd05716e233e65aa55394eafcdaf85f178698912cb29d79d \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5df082f8e3787e6ac2edf395113806999ae192425ce18b4ddba9ab20c135fa5b \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5df082f8e3787e6ac2edf395113806999ae192425ce18b4ddba9ab20c135fa5b \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5df082f8e3787e6ac2edf395113806999ae192425ce18b4ddba9ab20c135fa5b \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:49fb8f710319d6f3479b98d2c5dd7d0c9df8c1678b2c00727314dea1a8e933a1
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5c593bfd70309f87cd05716e233e65aa55394eafcdaf85f178698912cb29d79d \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5df082f8e3787e6ac2edf395113806999ae192425ce18b4ddba9ab20c135fa5b \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5df082f8e3787e6ac2edf395113806999ae192425ce18b4ddba9ab20c135fa5b \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5df082f8e3787e6ac2edf395113806999ae192425ce18b4ddba9ab20c135fa5b \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:49fb8f710319d6f3479b98d2c5dd7d0c9df8c1678b2c00727314dea1a8e933a1
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime


### PR DESCRIPTION
Use prod registry images to build a production-ready bundle for v1.14.2.

Release(s) used:
- prod cert-manager-operator-1-14: https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/cert-manager-oape-tenant/appstudio.redhat.com~v1alpha1~Release/cert-manager-operator-1-14-2-prod-w6wcr
- prod jetstack-cert-manager-1-14: https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/cert-manager-oape-tenant/appstudio.redhat.com~v1alpha1~Release/jetstack-cert-manager-1-14-2-prod-k2hg9