### PR TITLE
CM-556: Verify bundle image before updating fbc

### DIFF
--- a/hack/update_catalog.sh
+++ b/hack/update_catalog.sh
@@ -18,27 +18,70 @@ declare REPLICATE_BUNDLE_FILE_IN_CATALOGS
 declare USE_MIGRATE_LEVEL_FLAG
 
 CERT_MANAGER_CATALOG_NAME="openshift-cert-manager-operator"
+GREEN_COLOR_TEXT='\033[0;32m'
+RED_COLOR_TEXT='\033[0;31m'
+REVERT_COLOR_TEXT='\033[0m'
+
+log_info()
+{
+	echo -e "[$(date)] ${GREEN_COLOR_TEXT}-- INFO  --${REVERT_COLOR_TEXT} ${1}"
+}
+
+log_error()
+{
+	echo -e "[$(date)] ${RED_COLOR_TEXT}-- ERROR --${REVERT_COLOR_TEXT} ${1}"
+}
+
+verify_bundle_image()
+{
+	auth_file=""
+	if [[ -n ${REGISTRY_AUTH_FILE} ]]; then
+		auth_file=${REGISTRY_AUTH_FILE}
+	elif [[ -f ${XDG_RUNTIME_DIR}/containers/auth.json ]]; then
+		auth_file=${XDG_RUNTIME_DIR}/containers/auth.json
+	elif [[ -f ${HOME}/.docker/config.json ]]; then
+		auth_file=${HOME}/.docker/config.json
+	else
+		log_error "registry auth config lookup failed, expected REGISTRY_AUTH_FILE env var to be set, \
+			or config to be present in podman/docker recognised path"
+		exit 1
+	fi
+
+	log_info "inspecting ${OPERATOR_BUNDLE_IMAGE} bundle image"
+	media_type="$(podman run -e REGISTRY_AUTH_FILE="/tmp/auth.json" --rm -v "${auth_file}:/tmp/auth.json" \
+		quay.io/skopeo/stable:latest inspect --raw docker://"${OPERATOR_BUNDLE_IMAGE}" | jq -r .mediaType)"
+
+	case $media_type in
+		application/vnd.oci.image.manifest.v1+json|application/vnd.docker.distribution.manifest.v2+json)
+		;;
+	*)
+		log_error "bundle image not having expected media type, possibly index image was created"
+		exit 1
+	esac
+
+	return
+}
 
 render_catalog_bundle()
 {
-  render_cmd_args=""
-  # --migrate-level=bundle-object-to-csv-metadata is used for creating bundle metadata in `olm.csv.metadata` format.
-  # Refer https://github.com/konflux-ci/build-definitions/blob/main/task/fbc-validation/0.1/TROUBLESHOOTING.md for details.
-  if [[ ${USE_MIGRATE_LEVEL_FLAG} == "yes" ]]; then
-    render_cmd_args="--migrate-level=bundle-object-to-csv-metadata"
-  fi
+	render_cmd_args=""
+	# --migrate-level=bundle-object-to-csv-metadata is used for creating bundle metadata in `olm.csv.metadata` format.
+	# Refer https://github.com/konflux-ci/build-definitions/blob/main/task/fbc-validation/0.1/TROUBLESHOOTING.md for details.
+	if [[ ${USE_MIGRATE_LEVEL_FLAG} == "yes" ]]; then
+		render_cmd_args="--migrate-level=bundle-object-to-csv-metadata"
+	fi
 
-  bundle_file="${CATALOG_DIR}/${CERT_MANAGER_CATALOG_NAME}/${BUNDLE_FILE_NAME}"
-  echo "[$(date)] -- INFO  -- generating catalog bundle \"${bundle_file}\""
-  if ! "${OPM_TOOL_PATH}" render "${OPERATOR_BUNDLE_IMAGE}" $render_cmd_args -o yaml > "${bundle_file}"; then
-    echo "[$(date)] -- ERROR -- failed to render catalog bundle"
-    exit 1
-  fi
+	bundle_file="${CATALOG_DIR}/${CERT_MANAGER_CATALOG_NAME}/${BUNDLE_FILE_NAME}"
+	log_info "generating catalog bundle \"${bundle_file}\""
+	if ! "${OPM_TOOL_PATH}" render "${OPERATOR_BUNDLE_IMAGE}" $render_cmd_args -o yaml > "${bundle_file}"; then
+		log_error "failed to render catalog bundle"
+		exit 1
+	fi
 
-  if ! "${OPM_TOOL_PATH}" validate "${CATALOG_DIR}"; then
-    echo "[$(date)] -- ERROR -- failed to validate catalog"
-    exit 1
-  fi
+	if ! "${OPM_TOOL_PATH}" validate "${CATALOG_DIR}"; then
+		log_error "failed to validate catalog"
+		exit 1
+	fi
 }
 
 usage()
@@ -55,13 +98,13 @@ usage()
 
 replicate_catalog_bundle()
 {
-  if [[ "${REPLICATE_BUNDLE_FILE_IN_CATALOGS}" == "no" ]]; then
-    return
-  fi
+	if [[ "${REPLICATE_BUNDLE_FILE_IN_CATALOGS}" == "no" ]]; then
+		return
+	fi
 
-  bundle_file="${CATALOG_DIR}/${CERT_MANAGER_CATALOG_NAME}/${BUNDLE_FILE_NAME}"
+	bundle_file="${CATALOG_DIR}/${CERT_MANAGER_CATALOG_NAME}/${BUNDLE_FILE_NAME}"
 
-  find catalogs/*/catalog/openshift-cert-manager-operator -type d ! -path "${CATALOG_DIR}/*" -exec /bin/cp "${bundle_file}" {} \; -print
+	find catalogs/*/catalog/openshift-cert-manager-operator -type d ! -path "${CATALOG_DIR}/*" -exec /bin/cp "${bundle_file}" {} \; -print
 }
 
 ##############################################
@@ -69,7 +112,7 @@ replicate_catalog_bundle()
 ##############################################
 
 if [[ $# -ne 6 ]]; then
-  usage
+	usage
 fi
 
 OPM_TOOL_PATH=$1
@@ -79,32 +122,34 @@ BUNDLE_FILE_NAME=$4
 REPLICATE_BUNDLE_FILE_IN_CATALOGS=$5
 USE_MIGRATE_LEVEL_FLAG=$6
 
-echo "[$(date)] -- INFO  -- $*"
+log_info "$*"
 
 if [[ ! -d "${CATALOG_DIR}" ]]; then
-  echo "[$(date)] -- ERROR -- catalog directory \"${CATALOG_DIR}\" does not exist"
+	log_error "catalog directory \"${CATALOG_DIR}\" does not exist"
 	exit 1
 fi
 
 if [[ ! -x "${OPM_TOOL_PATH}" ]]; then
-  echo "[$(date)] -- ERROR -- \"${OPM_TOOL_PATH}\" does not exist or does not execute permissions"
-  exit 1
+	log_error "\"${OPM_TOOL_PATH}\" does not exist or does not execute permissions"
+	exit 1
 fi
 
 if [[ -z "${BUNDLE_FILE_NAME}" ]]; then
-  echo "[$(date)] -- ERROR -- \"\" bundle file name cannot be empty"
-  exit 1
+	log_error "bundle file name cannot be empty"
+	exit 1
 fi
 
 if [[ -z "${REPLICATE_BUNDLE_FILE_IN_CATALOGS}" ]] || [[ "${REPLICATE_BUNDLE_FILE_IN_CATALOGS}" != @(yes|no) ]]; then
-  echo "[$(date)] -- ERROR -- invalid value provided for \"REPLICATE_BUNDLE_FILE_IN_CATALOGS\", must be \"yes\" or \"no\""
-  exit 1
+	log_error "invalid value provided for \"REPLICATE_BUNDLE_FILE_IN_CATALOGS\", must be \"yes\" or \"no\""
+	exit 1
 fi
 
 if [[ -z "${USE_MIGRATE_LEVEL_FLAG}" ]] || [[ "${USE_MIGRATE_LEVEL_FLAG}" != @(yes|no) ]]; then
-  echo "[$(date)] -- ERROR -- invalid value provided for \"USE_MIGRATE_LEVEL_FLAG\", must be \"yes\" or \"no\""
-  exit 1
+	log_error "invalid value provided for \"USE_MIGRATE_LEVEL_FLAG\", must be \"yes\" or \"no\""
+	exit 1
 fi
+
+verify_bundle_image
 
 render_catalog_bundle
 


### PR DESCRIPTION
Bundle images created must not be multi-arch and must not be indexed too, when building catalog images through konflux. And for the catalog to function correctly in a multi-arch scenario, the referenced bundle digests must point to the correct type. They must not be `application/vnd.docker.distribution.manifest.list.v2+json`, but must be of `application/vnd.oci.image.manifest.v1+json` or `application/vnd.docker.distribution.manifest.v2+json` types.

References:
- https://konflux.pages.redhat.com/docs/users/getting-started/building-olm-products.html#building-bundle-images
- https://konflux.pages.redhat.com/docs/users/getting-started/building-olm-products.html#building-file-based-catalog-fbc-components:~:text=Bundle%20images%20SHOULD%20NOT%20be%20referenced,Index%20or%20manifest%20list%20is%20encountered