### PR TITLE
[release-1.15] NO-JIRA: override 'build-image-index' to false for single-arch-build-pipeline

### DIFF
--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -86,7 +86,7 @@ spec:
       description: Build a source image.
       name: build-source-image
       type: string
-    - default: "true"
+    - default: "false"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string


### PR DESCRIPTION
Following thread https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1744720525525849?thread_ts=1744715688.629639&cid=C04PZ7H0VA8

Konflux doc ref: https://konflux.pages.redhat.com/docs/users/getting-started/building-olm-products.html#building-file-based-catalog-fbc-components:~:text=Bundle%20images%20SHOULD%20NOT%20be%20referenced,Index%20or%20manifest%20list%20is%20encountered