### PR TITLE
NO-JIRA: change to use deterministic tag for catalog image

### DIFF
--- a/.tekton/cert-manager-operator-fbc-push.yaml
+++ b/.tekton/cert-manager-operator-fbc-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator/cert-manager-operator-fbc:{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator/cert-manager-operator-fbc:latest
   - name: dockerfile
     value: Containerfile.catalog
   - name: path-context


### PR DESCRIPTION
[Open to discussion] Experimentally use deterministic tag for FBC image. This may eliminate the error-prone and redundant process to retrieve the latest catalog build for testing.
