### PR TITLE
[release-1.14] NO-JIRA: Konflux build pipeline service account migrat…

### DIFF
--- a/.tekton/jetstack-cert-manager-acmesolver-1-14-pull-request.yaml
+++ b/.tekton/jetstack-cert-manager-acmesolver-1-14-pull-request.yaml
@@ -2,16 +2,16 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
-    build.appstudio.openshift.io/request: "configure-pac"
+    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
+    build.appstudio.openshift.io/request: configure-pac
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.14" &&
-      (".tekton/jetstack-cert-manager-acmesolver-1-14-pull-request.yaml".pathChanged() ||
-      "Containerfile.cert-manager.acmesolver".pathChanged() || "cert-manager/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-1.14" && (".tekton/jetstack-cert-manager-acmesolver-1-14-pull-request.yaml".pathChanged()
+      || "Containerfile.cert-manager.acmesolver".pathChanged() || "cert-manager/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: jetstack-cert-manager-1-14
@@ -35,14 +35,15 @@ spec:
     value: .
   - name: build-args
     value:
-    - "RELEASE_VERSION=v1.14.7"
-    - "COMMIT_SHA={{revision}}"
-    - "SOURCE_URL={{source_url}}"
+    - RELEASE_VERSION=v1.14.7
+    - COMMIT_SHA={{revision}}
+    - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "cert-manager"}'
   pipelineRef:
     name: multi-arch-build-pipeline
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-jetstack-cert-manager-acmesolver-1-14
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/jetstack-cert-manager-acmesolver-1-14-push.yaml
+++ b/.tekton/jetstack-cert-manager-acmesolver-1-14-push.yaml
@@ -2,15 +2,15 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
-    build.appstudio.openshift.io/request: "configure-pac"
+    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
+    build.appstudio.openshift.io/request: configure-pac
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.14" &&
-      (".tekton/jetstack-cert-manager-acmesolver-1-14-push.yaml".pathChanged() ||
-      "Containerfile.cert-manager.acmesolver".pathChanged() || "cert-manager/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-1.14" && (".tekton/jetstack-cert-manager-acmesolver-1-14-push.yaml".pathChanged()
+      || "Containerfile.cert-manager.acmesolver".pathChanged() || "cert-manager/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: jetstack-cert-manager-1-14
@@ -32,14 +32,15 @@ spec:
     value: .
   - name: build-args
     value:
-    - "RELEASE_VERSION=v1.14.7"
-    - "COMMIT_SHA={{revision}}"
-    - "SOURCE_URL={{source_url}}"
+    - RELEASE_VERSION=v1.14.7
+    - COMMIT_SHA={{revision}}
+    - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "cert-manager"}'
   pipelineRef:
     name: multi-arch-build-pipeline
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-jetstack-cert-manager-acmesolver-1-14
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
This PR changes Service Account used by build pipeline from "appstudio-pipeline" to dedicated to the Component Service Account.
Please merge the Service Account update to avoid broken builds when deprected "appstudio-pipeline" Service Account is removed.