### PR TITLE
[release-1.15] NO-JIRA: Konflux build pipeline service account migration to use components own

### DIFF
--- a/.tekton/cert-manager-istio-csr-1-15-pull-request.yaml
+++ b/.tekton/cert-manager-istio-csr-1-15-pull-request.yaml
@@ -2,16 +2,16 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
-    build.appstudio.openshift.io/request: "configure-pac"
+    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
+    build.appstudio.openshift.io/request: configure-pac
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.15" &&
-      (".tekton/cert-manager-istio-csr-1-15-pull-request.yaml".pathChanged() || "Containerfile.cert-manager-istio-csr".pathChanged() ||
-      "cert-manager-istio-csr/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-1.15" && (".tekton/cert-manager-istio-csr-1-15-pull-request.yaml".pathChanged()
+      || "Containerfile.cert-manager-istio-csr".pathChanged() || "cert-manager-istio-csr/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cert-manager-istio-csr-1-15
@@ -35,14 +35,15 @@ spec:
     value: .
   - name: build-args
     value:
-    - "RELEASE_VERSION=v0.14.0"
-    - "COMMIT_SHA={{revision}}"
-    - "SOURCE_URL={{source_url}}"
+    - RELEASE_VERSION=v0.14.0
+    - COMMIT_SHA={{revision}}
+    - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "cert-manager-istio-csr"}'
   pipelineRef:
     name: multi-arch-build-pipeline
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cert-manager-istio-csr-1-15
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-istio-csr-1-15-push.yaml
+++ b/.tekton/cert-manager-istio-csr-1-15-push.yaml
@@ -2,15 +2,15 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
-    build.appstudio.openshift.io/request: "configure-pac"
+    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
+    build.appstudio.openshift.io/request: configure-pac
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.15" &&
-      (".tekton/cert-manager-istio-csr-1-15-push.yaml".pathChanged() || "Containerfile.cert-manager-istio-csr".pathChanged() ||
-      "cert-manager-istio-csr/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-1.15" && (".tekton/cert-manager-istio-csr-1-15-push.yaml".pathChanged()
+      || "Containerfile.cert-manager-istio-csr".pathChanged() || "cert-manager-istio-csr/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cert-manager-istio-csr-1-15
@@ -32,14 +32,15 @@ spec:
     value: .
   - name: build-args
     value:
-    - "RELEASE_VERSION=v0.14.0"
-    - "COMMIT_SHA={{revision}}"
-    - "SOURCE_URL={{source_url}}"
+    - RELEASE_VERSION=v0.14.0
+    - COMMIT_SHA={{revision}}
+    - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "cert-manager-istio-csr"}'
   pipelineRef:
     name: multi-arch-build-pipeline
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cert-manager-istio-csr-1-15
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-operator-bundle-1-15-pull-request.yaml
+++ b/.tekton/cert-manager-operator-bundle-1-15-pull-request.yaml
@@ -2,17 +2,17 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
-    build.appstudio.openshift.io/request: "configure-pac"
+    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
+    build.appstudio.openshift.io/request: configure-pac
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.15" &&
-      (".tekton/cert-manager-operator-bundle-1-15-pull-request.yaml".pathChanged() ||
-      "Containerfile.cert-manager-operator.bundle".pathChanged() || "hack/bundle/render_templates.sh".pathChanged() ||
-      "cert-manager-operator/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-1.15" && (".tekton/cert-manager-operator-bundle-1-15-pull-request.yaml".pathChanged()
+      || "Containerfile.cert-manager-operator.bundle".pathChanged() || "hack/bundle/render_templates.sh".pathChanged()
+      || "cert-manager-operator/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cert-manager-operator-1-15
@@ -36,14 +36,15 @@ spec:
     value: .
   - name: build-args
     value:
-      - "RELEASE_VERSION=v1.15.1"
-      - "COMMIT_SHA={{revision}}"
-      - "SOURCE_URL={{source_url}}"
+    - RELEASE_VERSION=v1.15.1
+    - COMMIT_SHA={{revision}}
+    - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   pipelineRef:
     name: single-arch-build-pipeline
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cert-manager-operator-bundle-1-15
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-operator-bundle-1-15-push.yaml
+++ b/.tekton/cert-manager-operator-bundle-1-15-push.yaml
@@ -2,16 +2,16 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
-    build.appstudio.openshift.io/request: "configure-pac"
+    build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
+    build.appstudio.openshift.io/request: configure-pac
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.15" &&
-      (".tekton/cert-manager-operator-bundle-1-15-push.yaml".pathChanged() ||
-      "Containerfile.cert-manager-operator.bundle".pathChanged() || "hack/bundle/render_templates.sh".pathChanged() ||
-      "cert-manager-operator/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-1.15" && (".tekton/cert-manager-operator-bundle-1-15-push.yaml".pathChanged()
+      || "Containerfile.cert-manager-operator.bundle".pathChanged() || "hack/bundle/render_templates.sh".pathChanged()
+      || "cert-manager-operator/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cert-manager-operator-1-15
@@ -33,14 +33,15 @@ spec:
     value: .
   - name: build-args
     value:
-      - "RELEASE_VERSION=v1.15.1"
-      - "COMMIT_SHA={{revision}}"
-      - "SOURCE_URL={{source_url}}"
+    - RELEASE_VERSION=v1.15.1
+    - COMMIT_SHA={{revision}}
+    - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   pipelineRef:
     name: single-arch-build-pipeline
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cert-manager-operator-bundle-1-15
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -63,7 +63,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
This PR changes Service Account used by build pipeline from "appstudio-pipeline" to dedicated to the Component Service Account.

This PR is the changes created by bot in https://github.com/openshift/cert-manager-operator-release/pull/368 https://github.com/openshift/cert-manager-operator-release/pull/364 where the builds are failing since the PRs are not getting rebased.