### PR TITLE
CM-610: Update 1.16.1 staging build image sha256 references 

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,11 +8,11 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:41146965b3344b008ff0f6d119c1cb071efa7f02c742ce9af303b896ae43bff7 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4 \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4 \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4 \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:438d487c6b644319094f92250d43e0becf1bd0cc4b7d2864f4de72bacd1b9daf \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d30e755a266bb035d50e2b257e7a26c1fe6a5ccb66125576db99d537aa03ec27 \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:831e4b1e5aa6eed6fbb22f779ddbcb9c73e4bf6cc079d0c6652737a6a44e6320 \
     CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
@@ -38,38 +38,38 @@ ARG SOURCE_URL
 
 # Core bundle labels.
 LABEL com.redhat.component="cert-manager-operator-bundle-container" \
-      name="cert-manager/cert-manager-operator-bundle" \
-      summary="Cert Manager support for OpenShift" \
-      description="Cert Manager support for OpenShift" \
-      distribution-scope="public" \
-      release="${RELEASE_VERSION}" \
-      version="${RELEASE_VERSION}" \
-      url="${SOURCE_URL}" \
-      maintainer="Red Hat, Inc." \
-      vendor="Red Hat, Inc." \
-      com.redhat.delivery.operator.bundle=true \
-      com.redhat.openshift.versions="v4.14-v4.19" \
-      io.openshift.expose-services="" \
-      io.openshift.build.commit.id="${COMMIT_SHA}" \
-      io.openshift.build.source-location="${SOURCE_URL}" \
-      io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
-      io.openshift.maintainer.product="OpenShift Container Platform" \
-      io.openshift.tags="openshift,cert,cert-manager,cert-manager-operator,tls" \
-      io.k8s.display-name="openshift-cert-manager-operator-bundle" \
-      io.k8s.description="cert-manager-operator-bundle-container" \
-      operators.operatorframework.io.bundle.mediatype.v1="registry+v1" \
-      operators.operatorframework.io.bundle.manifests.v1=manifests/ \
-      operators.operatorframework.io.bundle.metadata.v1=metadata/ \
-      operators.operatorframework.io.bundle.package.v1="openshift-cert-manager-operator" \
-      operators.operatorframework.io.bundle.channel.default.v1="stable-v1" \
-      operators.operatorframework.io.bundle.channels.v1="stable-v1,stable-v1.16" \
-      operators.operatorframework.io.metrics.builder="operator-sdk-v1.25.1" \
-      operators.operatorframework.io.metrics.mediatype.v1="metrics+v1" \
-      operators.operatorframework.io.metrics.project_layout="go.kubebuilder.io/v3"
+    name="cert-manager/cert-manager-operator-bundle" \
+    summary="Cert Manager support for OpenShift" \
+    description="Cert Manager support for OpenShift" \
+    distribution-scope="public" \
+    release="${RELEASE_VERSION}" \
+    version="${RELEASE_VERSION}" \
+    url="${SOURCE_URL}" \
+    maintainer="Red Hat, Inc." \
+    vendor="Red Hat, Inc." \
+    com.redhat.delivery.operator.bundle=true \
+    com.redhat.openshift.versions="v4.14-v4.19" \
+    io.openshift.expose-services="" \
+    io.openshift.build.commit.id="${COMMIT_SHA}" \
+    io.openshift.build.source-location="${SOURCE_URL}" \
+    io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
+    io.openshift.maintainer.product="OpenShift Container Platform" \
+    io.openshift.tags="openshift,cert,cert-manager,cert-manager-operator,tls" \
+    io.k8s.display-name="openshift-cert-manager-operator-bundle" \
+    io.k8s.description="cert-manager-operator-bundle-container" \
+    operators.operatorframework.io.bundle.mediatype.v1="registry+v1" \
+    operators.operatorframework.io.bundle.manifests.v1=manifests/ \
+    operators.operatorframework.io.bundle.metadata.v1=metadata/ \
+    operators.operatorframework.io.bundle.package.v1="openshift-cert-manager-operator" \
+    operators.operatorframework.io.bundle.channel.default.v1="stable-v1" \
+    operators.operatorframework.io.bundle.channels.v1="stable-v1,stable-v1.16" \
+    operators.operatorframework.io.metrics.builder="operator-sdk-v1.25.1" \
+    operators.operatorframework.io.metrics.mediatype.v1="metrics+v1" \
+    operators.operatorframework.io.metrics.project_layout="go.kubebuilder.io/v3"
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1 \
-      operators.operatorframework.io.test.config.v1=tests/scorecard/
+    operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 COPY --from=builder /manifests /manifests
 COPY --from=builder /metadata /metadata


### PR DESCRIPTION
Update 1.16.1 staging build image sha256 references , based on the following staging build artifacts 

- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/jetstack-cert-manager-1-16/releases/jetstack-cert-manager-staging-1-16vtjn4/artifacts
- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/cert-manager-operator-1-16/releases/cert-manager-operator-staging-1-16gd5vl/artifacts

Tested with image pull
```sh
podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:831e4b1e5aa6eed6fbb22f779ddbcb9c73e4bf6cc079d0c6652737a6a44e6320                           
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:831e4b1e5aa6eed6fbb22f779ddbcb9c73e4bf6cc079d0c6652737a6a44e6320...
Getting image source signatures
Copying blob 5c90c176406b skipped: already exists  
Copying blob 025dc0dd6e06 done   | 
Copying config 302f401c4c done   | 
Writing manifest to image destination
302f401c4c711731704b25393f2cd5bba594bbf9a0f3af55c809ae46502df93f


------
podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f...
Getting image source signatures
Copying blob c32e2e40f647 skipped: already exists  
Copying blob 5c90c176406b skipped: already exists  
Copying config 9e04d254cd done   | 
Writing manifest to image destination
9e04d254cdd615f4e215421d8d3f0b04c7663ab0735ca4f215e005e8cab29164

----

podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d30e755a266bb035d50e2b257e7a26c1fe6a5ccb66125576db99d537aa03ec27
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d30e755a266bb035d50e2b257e7a26c1fe6a5ccb66125576db99d537aa03ec27...
Getting image source signatures
Copying blob 94d9ff4bda8d done   | 
Copying blob 5c90c176406b skipped: already exists  
Copying config 50c6c5282a done   | 
Writing manifest to image destination
50c6c5282a6dd0bd357ef4a8394261e0f7a34d4f3a1a7f6f51b5c33a2fa3d990
```

- Keeping `CERT_MANAGER_ISTIOCSR_IMAGE` unchanged. 

/assign @bharath-b-rh 