### PR TITLE
CM-613: Upgrade 1.16.1 staging builds to GA

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,11 +8,11 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d30e755a266bb035d50e2b257e7a26c1fe6a5ccb66125576db99d537aa03ec27 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:831e4b1e5aa6eed6fbb22f779ddbcb9c73e4bf6cc079d0c6652737a6a44e6320 \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d30e755a266bb035d50e2b257e7a26c1fe6a5ccb66125576db99d537aa03ec27 \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:831e4b1e5aa6eed6fbb22f779ddbcb9c73e4bf6cc079d0c6652737a6a44e6320 \
     CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl


### PR DESCRIPTION
Update 1.16.1 prod build image sha256 references , based on the following build artifacts

- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/jetstack-cert-manager-1-16/releases/jetstack-cert-manager-prod-1-166ctns
- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/cert-manager-operator-1-16/releases/cert-manager-operator-prod-1-16t4fzx/

Tested with image pull

```sh
podman pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:831e4b1e5aa6eed6fbb22f779ddbcb9c73e4bf6cc079d0c6652737a6a44e6320
Trying to pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:831e4b1e5aa6eed6fbb22f779ddbcb9c73e4bf6cc079d0c6652737a6a44e6320...
Getting image source signatures
Checking if image destination supports signatures
Copying blob 025dc0dd6e06 skipped: already exists  
Copying blob 5c90c176406b skipped: already exists  
Copying config 302f401c4c done   | 
Writing manifest to image destination
Storing signatures
302f401c4c711731704b25393f2cd5bba594bbf9a0f3af55c809ae46502df93f

----
podman pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f
Trying to pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f...
Getting image source signatures
Checking if image destination supports signatures
Copying blob c32e2e40f647 skipped: already exists  
Copying blob 5c90c176406b skipped: already exists  
Copying config 9e04d254cd done   | 
Writing manifest to image destination
Storing signatures
9e04d254cdd615f4e215421d8d3f0b04c7663ab0735ca4f215e005e8cab29164

----
podman pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d30e755a266bb035d50e2b257e7a26c1fe6a5ccb66125576db99d537aa03ec27
Trying to pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d30e755a266bb035d50e2b257e7a26c1fe6a5ccb66125576db99d537aa03ec27...
Getting image source signatures
Checking if image destination supports signatures
Copying blob 5c90c176406b skipped: already exists  
Copying blob 94d9ff4bda8d skipped: already exists  
Copying config 50c6c5282a done   | 
Writing manifest to image destination
Storing signatures
50c6c5282a6dd0bd357ef4a8394261e0f7a34d4f3a1a7f6f51b5c33a2fa3d990
```