### PR TITLE
CM-585: [release-1.17] Update 1.17.0 staging build image sha256 reference

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,11 +8,11 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:41146965b3344b008ff0f6d119c1cb071efa7f02c742ce9af303b896ae43bff7 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4 \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4 \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4 \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:438d487c6b644319094f92250d43e0becf1bd0cc4b7d2864f4de72bacd1b9daf \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:4d5e238300ce6f427a1045d51d6b37a4e5c5633985208ebb44f91e7dd53897d9 \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:96d51e3a64bf30cbd92836c7cbd82f06edca16eef78ab1432757d34c16628659 \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:96d51e3a64bf30cbd92836c7cbd82f06edca16eef78ab1432757d34c16628659 \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:96d51e3a64bf30cbd92836c7cbd82f06edca16eef78ab1432757d34c16628659 \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4f7c045819c39e176a6090efdaba6ec736edf772d88fc87dd1c6fb33d3b5b26b \
     CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl


### PR DESCRIPTION
Update 1.17.0 staging build image sha256 references, based on the following staging build artifacts

- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/cert-manager-operator-1-17/releases/cert-manager-operator-1-17-slv5t-456c52a-p6xqq

- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/jetstack-cert-manager-1-17/releases/jetstack-cert-manager-1-17-cxns4-456c52a-8cxch

Tested with image pull
```sh

> podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:4d5e238300ce6f427a1045d51d6b37a4e5c5633985208ebb44f91e7dd53897d9
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:4d5e238300ce6f427a1045d51d6b37a4e5c5633985208ebb44f91e7dd53897d9...
Getting image source signatures
Copying blob sha256:eb0aa7d800282f61252f32fd357464584bd994d09c59433b1c387ed22eb1a647
Copying blob sha256:92ae2ab59139bf24f64d74983458049ed75c60b8cfe03cc7ffc1ed5de10a96cb
Copying config sha256:c225ab05ac61348dcab9d64f23afc553f7fea220daf75a0da5a23d3cec31312c
Writing manifest to image destination
c225ab05ac61348dcab9d64f23afc553f7fea220daf75a0da5a23d3cec31312c

............................................................................................................................ 

> podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:96d51e3a64bf30cbd92836c7cbd82f06edca16eef78ab1432757d34c16628659
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:96d51e3a64bf30cbd92836c7cbd82f06edca16eef78ab1432757d34c16628659...
Getting image source signatures
Copying blob sha256:b26e87948b8493a0efbfbe405f0e2c80ff45b885d7a269836d967f91c4675b9d
Copying blob sha256:92ae2ab59139bf24f64d74983458049ed75c60b8cfe03cc7ffc1ed5de10a96cb
Copying config sha256:f1da035a88406d788be6ed694b0666a249f67bc5bf06dd56ce5172b5a3a5bc70
Writing manifest to image destination
f1da035a88406d788be6ed694b0666a249f67bc5bf06dd56ce5172b5a3a5bc70

............................................................................................................................

> podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4f7c045819c39e176a6090efdaba6ec736edf772d88fc87dd1c6fb33d3b5b26b
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4f7c045819c39e176a6090efdaba6ec736edf772d88fc87dd1c6fb33d3b5b26b...
Getting image source signatures
Copying blob sha256:f4ae31d9f1eb2d7da90bb72b4b8b003fb47395ca50f59281966ede7ece6b66cc
Copying blob sha256:92ae2ab59139bf24f64d74983458049ed75c60b8cfe03cc7ffc1ed5de10a96cb
Copying config sha256:34798c8194775c79ef56f48f05f376eb7bf653247f8ed4456e6f18284751cab3
Writing manifest to image destination
34798c8194775c79ef56f48f05f376eb7bf653247f8ed4456e6f18284751cab3
```

- Keeping `CERT_MANAGER_ISTIOCSR_IMAGE` unchanged.
 
/cc @bharath-b-rh 
