### PR TITLE
OCPBUGS-60289: Fix upgrade path for v1.15.0->v1.15.1->v1.16.1

### DIFF
--- a/catalogs/v4.14/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.14/catalog/openshift-cert-manager-operator/channel.yaml
@@ -36,10 +36,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -212,10 +213,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 name: stable-v1.16
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.15/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.15/catalog/openshift-cert-manager-operator/channel.yaml
@@ -21,10 +21,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -102,10 +103,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 name: stable-v1.16
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.16/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.16/catalog/openshift-cert-manager-operator/channel.yaml
@@ -21,10 +21,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 - name: cert-manager-operator.v1.17.0
   replaces: cert-manager-operator.v1.16.1
   skipRange: '>=1.16.1 <1.17.0'
@@ -105,10 +106,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 name: stable-v1.16
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -135,10 +137,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 - name: cert-manager-operator.v1.17.0
   replaces: cert-manager-operator.v1.16.1
   skipRange: '>=1.16.1 <1.17.0'

--- a/catalogs/v4.17/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.17/catalog/openshift-cert-manager-operator/channel.yaml
@@ -16,10 +16,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 - name: cert-manager-operator.v1.17.0
   replaces: cert-manager-operator.v1.16.1
   skipRange: '>=1.16.1 <1.17.0'
@@ -75,10 +76,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 name: stable-v1.16
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -100,10 +102,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 - name: cert-manager-operator.v1.17.0
   replaces: cert-manager-operator.v1.16.1
   skipRange: '>=1.16.1 <1.17.0'

--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/channel.yaml
@@ -10,10 +10,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 - name: cert-manager-operator.v1.17.0
   replaces: cert-manager-operator.v1.16.1
   skipRange: '>=1.16.1 <1.17.0'
@@ -43,10 +44,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 name: stable-v1.16
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -62,10 +64,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 - name: cert-manager-operator.v1.17.0
   replaces: cert-manager-operator.v1.16.1
   skipRange: '>=1.16.1 <1.17.0'

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
@@ -10,10 +10,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 - name: cert-manager-operator.v1.17.0
   replaces: cert-manager-operator.v1.16.1
   skipRange: '>=1.16.1 <1.17.0'
@@ -43,10 +44,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 name: stable-v1.16
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -62,10 +64,11 @@ entries:
   replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.0'
 - name: cert-manager-operator.v1.16.1
-  replaces: cert-manager-operator.v1.16.0
+  # Update this to new v1.15 z stream release, when added.
+  replaces: cert-manager-operator.v1.15.1
   skipRange: '>=1.15.1 <1.16.1'
-  skips: 
-  - cert-manager-operator.v1.15.1
+  skips:
+  - cert-manager-operator.v1.16.0
 - name: cert-manager-operator.v1.17.0
   replaces: cert-manager-operator.v1.16.1
   skipRange: '>=1.16.1 <1.17.0'


### PR DESCRIPTION
Update channel entries for all OCP index (v4.14-v4.19) having support for `v1.16.0` in `stable-v1`, `stable-v1.16`, `stable-v1.17` (if has) channels. 

And we would need to re-release FBCs for all supported OCP versions (v4.14-v4.19).

```yaml
- name: cert-manager-operator.v1.16.1
  ## Update this to new v1.15 z stream release, when added.
  replaces: cert-manager-operator.v1.15.1
  skipRange: '>=1.15.1 <1.16.1'
  skips: 
  - cert-manager-operator.v1.16.0
```

See the following Slack threads for more details:

- https://redhat-internal.slack.com/archives/C3VS0LV41/p1755073224707029
- https://redhat-internal.slack.com/archives/C045Y7FL3A6/p1754980744497329


/cc @bharath-b-rh @lunarwhite 
