### PR TITLE
CM-641: [release-1.18] Update 1.18.0 staging build image sha256 reference

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,12 +8,12 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:4d5e238300ce6f427a1045d51d6b37a4e5c5633985208ebb44f91e7dd53897d9 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:96d51e3a64bf30cbd92836c7cbd82f06edca16eef78ab1432757d34c16628659 \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:96d51e3a64bf30cbd92836c7cbd82f06edca16eef78ab1432757d34c16628659 \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:96d51e3a64bf30cbd92836c7cbd82f06edca16eef78ab1432757d34c16628659 \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4f7c045819c39e176a6090efdaba6ec736edf772d88fc87dd1c6fb33d3b5b26b \
-    CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:136431a689641032a800c9bdc198b54dd887abf565f07c2e9a8dd54611d7c8cc \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:18adbfbfebfeebfc95c390b9114efdcfbb5446ac3564ab0ca24d6cb0afb74fad \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:18adbfbfebfeebfc95c390b9114efdcfbb5446ac3564ab0ca24d6cb0afb74fad \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:18adbfbfebfeebfc95c390b9114efdcfbb5446ac3564ab0ca24d6cb0afb74fad \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:25209c8ff1b8c03bd687775ddde802ab8de7211c5acd2bde5797aeedb3633239 \
+    CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:b90f3e01f9901e015b351c2a89ca61e191413867b92e456a7fae4a4d0e0e2998
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime


### PR DESCRIPTION
Update 1.18.0 staging build image sha256 references, based on the following staging build artifacts

- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/cert-manager-istio-csr-1-18/releases/cert-manager-istio-csr-1-18-zdcsx-8e0ed3d-2qrt9
- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/jetstack-cert-manager-1-18/releases/jetstack-cert-manager-1-18-6x44f-8e0ed3d-dfjn7
- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/cert-manager-operator-1-18/releases/cert-manager-operator-1-18-shwzk-8e0ed3d-mcjkd

Tested with image pull

```sh
> podman pull registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:b90f3e01f9901e015b351c2a89ca61e191413867b92e456a7fae4a4d0e0e2998
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:b90f3e01f9901e015b351c2a89ca61e191413867b92e456a7fae4a4d0e0e2998...
Getting image source signatures
Copying blob sha256:051e8b4c12ba5d188bff378b25243d4575c96d49eb4fc4308f7c96d2f877b316
Copying blob sha256:ade2dd5c7a4d7782fb23179ea2b98acde7654a5e5350768df2cb9787b4e5757d
Copying config sha256:2d73cd96b2d688c55630022e4673dfafca5fd498f3529d1d41b2099b7ca7f95e
Writing manifest to image destination
2d73cd96b2d688c55630022e4673dfafca5fd498f3529d1d41b2099b7ca7f95e
.......................................................... 

> podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:18adbfbfebfeebfc95c390b9114efdcfbb5446ac3564ab0ca24d6cb0afb74fad
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:18adbfbfebfeebfc95c390b9114efdcfbb5446ac3564ab0ca24d6cb0afb74fad...
Getting image source signatures
Copying blob sha256:ea2b18e17f4844a740e4dc1960c21f7751b4f05e5f71db7c4c82ab12dbb7da60
Copying blob sha256:ade2dd5c7a4d7782fb23179ea2b98acde7654a5e5350768df2cb9787b4e5757d
Copying config sha256:a9827b6ac708ae0311791836da891ba07cb1b573cef489a8be2277f673b71b45
Writing manifest to image destination
a9827b6ac708ae0311791836da891ba07cb1b573cef489a8be2277f673b71b45

........................................................ 

> podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:25209c8ff1b8c03bd687775ddde802ab8de7211c5acd2bde5797aeedb3633239
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:25209c8ff1b8c03bd687775ddde802ab8de7211c5acd2bde5797aeedb3633239...
Getting image source signatures
Copying blob sha256:3282b086f633b05f9438f4fe45a513a81939c290f6ca230d3b48db15137a02be
Copying blob sha256:ade2dd5c7a4d7782fb23179ea2b98acde7654a5e5350768df2cb9787b4e5757d
Copying config sha256:55830a1cbca9a1f9094b86450dfe02f9010215d0713946a64f12c1556581d4e7
Writing manifest to image destination
55830a1cbca9a1f9094b86450dfe02f9010215d0713946a64f12c1556581d4e7
........................................................ 

> podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:136431a689641032a800c9bdc198b54dd887abf565f07c2e9a8dd54611d7c8cc
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:136431a689641032a800c9bdc198b54dd887abf565f07c2e9a8dd54611d7c8cc...
Getting image source signatures
Copying blob sha256:e9d188bbc79ea26f8fbe51c4d4f06508fb7756e10c540cbaeee0e7940567e7e5
Copying blob sha256:ade2dd5c7a4d7782fb23179ea2b98acde7654a5e5350768df2cb9787b4e5757d
Copying config sha256:5b18ab2726482bb29c1c277b80fd06de53581b7bd8bb1be029aa83d06514bc83
Writing manifest to image destination
5b18ab2726482bb29c1c277b80fd06de53581b7bd8bb1be029aa83d06514bc83
```

/cc @bharath-b-rh 