### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cert-manager-istio-csr-1-16

### DIFF
--- a/Containerfile.cert-manager-istio-csr
+++ b/Containerfile.cert-manager-istio-csr
@@ -42,6 +42,7 @@ LABEL com.redhat.component="cert-manager-istio-csr-container" \
       io.openshift.build.source-location="${SOURCE_URL}" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.k8s.display-name="cert-manager-istio-csr" \
-      io.k8s.description="cert-manager-istio-csr-container"
+      io.k8s.description="cert-manager-istio-csr-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.15::el9"
 
 ENTRYPOINT ["/usr/local/bin/cert-manager-istio-csr"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
