### PR TITLE
KONFLUX-6210: chore: fix and set name and cpe label for cert-manager-operator-bundle-1-16

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -57,6 +57,7 @@ LABEL com.redhat.component="cert-manager-operator-bundle-container" \
     io.openshift.tags="openshift,cert,cert-manager,cert-manager-operator,tls" \
     io.k8s.display-name="openshift-cert-manager-operator-bundle" \
     io.k8s.description="cert-manager-operator-bundle-container" \
+    cpe="cpe:/a:redhat:cert_manager:1.16::el9" \
     operators.operatorframework.io.bundle.mediatype.v1="registry+v1" \
     operators.operatorframework.io.bundle.manifests.v1=manifests/ \
     operators.operatorframework.io.bundle.metadata.v1=metadata/ \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
