### PR TITLE
KONFLUX-6210: chore: fix and set name and cpe label for cert-manager-operator-1-16

### DIFF
--- a/Containerfile.cert-manager-operator
+++ b/Containerfile.cert-manager-operator
@@ -32,6 +32,7 @@ LABEL com.redhat.component="cert-manager-operator-container" \
       description="cert-manager-operator-container" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="cpe:/a:redhat:cert_manager:1.16::el9" \
       io.openshift.expose-services="" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
