### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jetstack-cert-manager-acmesolver-1-16

### DIFF
--- a/Containerfile.cert-manager.acmesolver
+++ b/Containerfile.cert-manager.acmesolver
@@ -48,6 +48,7 @@ LABEL com.redhat.component="jetstack-cert-manager-acmesolver-container" \
       io.openshift.build.source-location="${SOURCE_URL}" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.k8s.display-name="cert-manager-acmesolver" \
-      io.k8s.description="jetstack-cert-manager-acmesolver-container"
+      io.k8s.description="jetstack-cert-manager-acmesolver-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.16::el9"
 
 ENTRYPOINT ["/app/cmd/acmesolver/acmesolver"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
