### PR TITLE
KONFLUX-6210: chore: fix and set name and cpe label for cert-manager-operator-1-17

### DIFF
--- a/Containerfile.cert-manager-operator
+++ b/Containerfile.cert-manager-operator
@@ -39,6 +39,7 @@ LABEL com.redhat.component="cert-manager-operator-container" \
       io.openshift.maintainer.product="OpenShift Container Platform" \
       io.openshift.tags="data,images,operator,cert-manager" \
       io.k8s.display-name="openshift-cert-manager-operator" \
-      io.k8s.description="cert-manager-operator-container"
+      io.k8s.description="cert-manager-operator-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.17::el9"
 
 ENTRYPOINT ["/usr/bin/cert-manager-operator"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
