### PR TITLE
KONFLUX-6210: chore: fix and set name and cpe label for jetstack-cert-manager-acmesolver-1-17

### DIFF
--- a/Containerfile.cert-manager.acmesolver
+++ b/Containerfile.cert-manager.acmesolver
@@ -42,6 +42,7 @@ LABEL com.redhat.component="jetstack-cert-manager-acmesolver-container" \
       description="jetstack-cert-manager-acmesolver-container" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="cpe:/a:redhat:cert_manager:1.17::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="data,images,cert-manager-acmesolver" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
