### PR TITLE
KONFLUX-6210: chore: fix and set name and cpe label for cert-manager-operator-bundle-1-14

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -37,6 +37,7 @@ ARG SOURCE_URL
 
 # Core bundle labels.
 LABEL com.redhat.component="cert-manager-operator-bundle-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.14::el9" \
       name="cert-manager/cert-manager-operator-bundle" \
       summary="Cert Manager support for OpenShift" \
       description="Cert Manager support for OpenShift" \
@@ -65,6 +66,7 @@ LABEL com.redhat.component="cert-manager-operator-bundle-container" \
       operators.operatorframework.io.metrics.builder="operator-sdk-v1.25.1" \
       operators.operatorframework.io.metrics.mediatype.v1="metrics+v1" \
       operators.operatorframework.io.metrics.project_layout="go.kubebuilder.io/v3"
+
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1 \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
