### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cert-manager-operator-bundle-1-15

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -47,6 +47,7 @@ LABEL com.redhat.component="cert-manager-operator-bundle-container" \
       url="${SOURCE_URL}" \
       maintainer="Red Hat, Inc." \
       vendor="Red Hat, Inc." \
+      cpe="cpe:/a:redhat:cert_manager:1.15::el9" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.openshift.versions="v4.14-v4.19" \
       io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
