### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cert-manager-operator-1-15

### DIFF
--- a/Containerfile.cert-manager-operator
+++ b/Containerfile.cert-manager-operator
@@ -25,7 +25,9 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="cert-manager-operator-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.15::el9" \
       name="cert-manager/cert-manager-operator-rhel9" \
+
       version="${RELEASE_VERSION}" \
       summary="cert-manager-operator" \
       maintainer="Red Hat, Inc." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
