### PR TITLE
CM-742: Update 1.16.2 staging build image sha256 reference

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,11 +8,11 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d30e755a266bb035d50e2b257e7a26c1fe6a5ccb66125576db99d537aa03ec27 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:33308217d2226c2555eb18020710d16175295a8e349263a5435e4b158bbc735f \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:831e4b1e5aa6eed6fbb22f779ddbcb9c73e4bf6cc079d0c6652737a6a44e6320 \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f180b21ed62894a70d638f76ae3bbced6814e1e6c5910413b5626f3bf397bc8d \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:f57f356c215d134b840a973b3a5fe0a9da1e5c5acf1d60628a5e412bf4253fb7 \
     CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl


### PR DESCRIPTION
Update 1.16.2 staging build image sha256 references, based on the following staging build artifacts

## Steps

We need to trigger a manual build for `jetstack-cert-manager-1-16`

```sh
trigger_konflux_build () 
{ 
    component_list=$(echo $1 | sed 's/,/ /g');
    namespace=$2;
    args="";
    if [[ -n $namespace ]]; then
        args="-n $namespace";
    fi;
    oc annotate components.appstudio.redhat.com $component_list build.appstudio.openshift.io/request=trigger-pac-build $args
}

trigger_konflux_build jetstack-cert-manager-1-16,jetstack-cert-manager-acmesolver-1-16
```

- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/cert-manager-operator-1-16/releases/cert-manager-operator-1-16-rtl96-d81da1c-d8r44/artifacts
- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/jetstack-cert-manager-1-16/releases/jetstack-cert-manager-1-16-vm4gr-d81da1c-5skfr/artifacts

```
$ podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9:v1.16.5
$ podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9:v1.16.5
$ podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9:v1.16.2
```

```
> podman images --digests | grep "cert-manager"
registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9             v1.16.5                            sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc  d3a2830b3496  2 hours ago    431 MB
registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9  v1.16.5                            sha256:f57f356c215d134b840a973b3a5fe0a9da1e5c5acf1d60628a5e412bf4253fb7  5ede0b9c40c7  4 hours ago    431 MB
registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9             v1.16.2                            sha256:f180b21ed62894a70d638f76ae3bbced6814e1e6c5910413b5626f3bf397bc8d  942285fe3129  21 hours ago   345 MB
```

```
> podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f180b21ed62894a70d638f76ae3bbced6814e1e6c5910413b5626f3bf397bc8d
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f180b21ed62894a70d638f76ae3bbced6814e1e6c5910413b5626f3bf397bc8d...
Getting image source signatures
Copying blob sha256:a942cdf36378e50e1ce09dbbd5de70d6d966d33ee5242fae69dcf1dae7e12bcd
Copying blob sha256:f412c943a31bcef92dda081777d27487c3d20cbca8f50177391fff538e1e7f67
Copying config sha256:942285fe3129805cc53039e5818782993d14bf17f916a6308ae9361710a50878
Writing manifest to image destination
942285fe3129805cc53039e5818782993d14bf17f916a6308ae9361710a50878

...................................................................... 
> podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc...
Getting image source signatures
Copying blob sha256:67f7a7d52d92355626ca1dcc65318cef902ddf5a2b27802aac776b5da13a92b7
Copying blob sha256:f412c943a31bcef92dda081777d27487c3d20cbca8f50177391fff538e1e7f67
Copying config sha256:d3a2830b3496dfe7a6a9d124e7faeedc39ddd6219fe15ce9786efb46063200bb
Writing manifest to image destination
d3a2830b3496dfe7a6a9d124e7faeedc39ddd6219fe15ce9786efb46063200bb

......................................................................
> podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:f57f356c215d134b840a973b3a5fe0a9da1e5c5acf1d60628a5e412bf4253fb7
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:f57f356c215d134b840a973b3a5fe0a9da1e5c5acf1d60628a5e412bf4253fb7...
Getting image source signatures
Copying blob sha256:f898d7e3f8c5ef420d2177cc15549a147fcb808593361f8deb6b7017050ddd40
Copying blob sha256:f412c943a31bcef92dda081777d27487c3d20cbca8f50177391fff538e1e7f67
Copying config sha256:5ede0b9c40c760dcd73fddd57dfaa0f1d97bee54e67a48b682c15f3c4b84e37a
Writing manifest to image destination
5ede0b9c40c760dcd73fddd57dfaa0f1d97bee54e67a48b682c15f3c4b84e37a
```

- Keeping `CERT_MANAGER_ISTIOCSR_IMAGE` unchanged.