### PR TITLE
CM-740: [release-1.16] [GA] Promote 1.16.2 staging builds to GA

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,11 +8,11 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f180b21ed62894a70d638f76ae3bbced6814e1e6c5910413b5626f3bf397bc8d \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:f57f356c215d134b840a973b3a5fe0a9da1e5c5acf1d60628a5e412bf4253fb7 \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f180b21ed62894a70d638f76ae3bbced6814e1e6c5910413b5626f3bf397bc8d \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:f57f356c215d134b840a973b3a5fe0a9da1e5c5acf1d60628a5e412bf4253fb7 \
     CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
@@ -62,8 +62,8 @@ LABEL com.redhat.component="cert-manager-operator-bundle-container" \
     operators.operatorframework.io.bundle.manifests.v1=manifests/ \
     operators.operatorframework.io.bundle.metadata.v1=metadata/ \
     operators.operatorframework.io.bundle.package.v1="openshift-cert-manager-operator" \
-    operators.operatorframework.io.bundle.channel.default.v1="stable-v1" \
-    operators.operatorframework.io.bundle.channels.v1="stable-v1,stable-v1.16" \
+    operators.operatorframework.io.bundle.channel.default.v1="stable-v1.16" \
+    operators.operatorframework.io.bundle.channels.v1="stable-v1.16" \
     operators.operatorframework.io.metrics.builder="operator-sdk-v1.25.1" \
     operators.operatorframework.io.metrics.mediatype.v1="metrics+v1" \
     operators.operatorframework.io.metrics.project_layout="go.kubebuilder.io/v3"


### PR DESCRIPTION
Update 1.16.2 prod build image sha256 references, based on the following build artifacts

- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/cert-manager-operator-1-16/releases/cert-manager-operator-prod-1-16tfwc6
- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/jetstack-cert-manager-1-16/releases/jetstack-cert-manager-prod-1-16wkqsm

- [x] Tested with image pull

```sh
> podman pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f180b21ed62894a70d638f76ae3bbced6814e1e6c5910413b5626f3bf397bc8d
Trying to pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f180b21ed62894a70d638f76ae3bbced6814e1e6c5910413b5626f3bf397bc8d...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:a942cdf36378e50e1ce09dbbd5de70d6d966d33ee5242fae69dcf1dae7e12bcd
Copying blob sha256:f412c943a31bcef92dda081777d27487c3d20cbca8f50177391fff538e1e7f67
Copying config sha256:942285fe3129805cc53039e5818782993d14bf17f916a6308ae9361710a50878
Writing manifest to image destination
Storing signatures
942285fe3129805cc53039e5818782993d14bf17f916a6308ae9361710a50878

 ~/go/src/github.com/chiragkyal/cert-manager-operator-release | on 1.16.2-ga *1 !1 ......................................................................... took 11s | % | at 14:21:30
> podman pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc
Trying to pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:2e89d528d5d10ab7caa930a0802e7d64fd9aff5adef6e9688d15f747465cc8dc...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:67f7a7d52d92355626ca1dcc65318cef902ddf5a2b27802aac776b5da13a92b7
Copying blob sha256:f412c943a31bcef92dda081777d27487c3d20cbca8f50177391fff538e1e7f67
Copying config sha256:d3a2830b3496dfe7a6a9d124e7faeedc39ddd6219fe15ce9786efb46063200bb
Writing manifest to image destination
Storing signatures
d3a2830b3496dfe7a6a9d124e7faeedc39ddd6219fe15ce9786efb46063200bb

 ~/go/src/github.com/chiragkyal/cert-manager-operator-release | on 1.16.2-ga *1 !1 .......................................................................... took 9s | % | at 14:22:00
> podman pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:f57f356c215d134b840a973b3a5fe0a9da1e5c5acf1d60628a5e412bf4253fb7
Trying to pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:f57f356c215d134b840a973b3a5fe0a9da1e5c5acf1d60628a5e412bf4253fb7...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:f898d7e3f8c5ef420d2177cc15549a147fcb808593361f8deb6b7017050ddd40
Copying blob sha256:f412c943a31bcef92dda081777d27487c3d20cbca8f50177391fff538e1e7f67
Copying config sha256:5ede0b9c40c760dcd73fddd57dfaa0f1d97bee54e67a48b682c15f3c4b84e37a
Writing manifest to image destination
Storing signatures
5ede0b9c40c760dcd73fddd57dfaa0f1d97bee54e67a48b682c15f3c4b84e37a
```