### PR TITLE
no-jira: Add mytreya-rh to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,8 @@ reviewers:
   - TrilokGeer
   - swghosh
   - bharath-b-rh
+  - mytreya-rh
 approvers:
   - TrilokGeer
   - bharath-b-rh
+  - mytreya-rh


### PR DESCRIPTION
As i will be leading the cert-manager work and reviewing the PRs, i would need to be able approve the PRs raised in this repo.

- [x]  https://github.com/kubernetes/community/blob/master/community-membership.md#approver

i read and fully understand the roles and responsibilities.
Seeking exception for the below 2 requirements:
Primary reviewer for at least 10 substantial PRs to the codebase
Reviewed or merged at least 30 PRs to the codebase
i have perhaps reviewed 4 substantial PRs during the cert-manager-operator 1.18.0 work, and in total about 10 PRs overall.