### PR TITLE
[release-1.18] CM-757: Update bundle manifest with latest image builds

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,12 +8,12 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:136431a689641032a800c9bdc198b54dd887abf565f07c2e9a8dd54611d7c8cc \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:18adbfbfebfeebfc95c390b9114efdcfbb5446ac3564ab0ca24d6cb0afb74fad \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:18adbfbfebfeebfc95c390b9114efdcfbb5446ac3564ab0ca24d6cb0afb74fad \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:18adbfbfebfeebfc95c390b9114efdcfbb5446ac3564ab0ca24d6cb0afb74fad \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:25209c8ff1b8c03bd687775ddde802ab8de7211c5acd2bde5797aeedb3633239 \
-    CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:b90f3e01f9901e015b351c2a89ca61e191413867b92e456a7fae4a4d0e0e2998
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5c2f39352dc743bb6f7dabe9b0b4b757f658c387240204d6874a845c9f7fa254 \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519 \
+    CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime


### PR DESCRIPTION
The PR is for updating the operator and operand image sha's to the latest stage builds which are based on `https://github.com/openshift/cert-manager-operator-release/commit/d13a856db70a012584ffa155cf15a671e0e7f54f` commit.