### PR TITLE
CM-757: Updates cert-manager-operator latest image in bundle

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,7 +8,7 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5c2f39352dc743bb6f7dabe9b0b4b757f658c387240204d6874a845c9f7fa254 \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d \
     CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
     CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
     CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \


### PR DESCRIPTION
PR is for updating the image ref of cert-manager-operator in the operator bundle. The operator image is based on `edb01b42562df36f3292b69200ea23e0dbdbf6a4` commit.