### PR TITLE
CM-769,CM-770: Updates image sha cert-manager-operator in bundle

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,7 +8,7 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594 \
     CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
     CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
     CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \


### PR DESCRIPTION
The PR is for updating the sha of cert-manager-operator to the latest in bundle manifests, which is based on `fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594` commit.

```
$ podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594...
Getting image source signatures
Copying blob 175a176f7499 skipped: already exists  
Copying blob 82541c6e95e6 skipped: already exists  
Copying config 670fec592b done   | 
Writing manifest to image destination
670fec592b9b87aaaf20d5db38d7dd8a81152a8b31493db0f0434084fb9d01e4

```

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594 | grep "io.openshift.build.commit.url"
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/7d5a26e621d77295e9fcda60d216f5da492a7ac0",
               "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/7d5a26e621d77295e9fcda60d216f5da492a7ac0",
                    "created_by": "/bin/sh -c #(nop) LABEL com.redhat.component=\"cert-manager-operator-container\"       name=\"cert-manager/cert-manager-operator-rhel9\"       version=\"${RELEASE_VERSION}\"       summary=\"cert-manager-operator\"       maintainer=\"Red Hat, Inc.\"       description=\"cert-manager-operator-container\"       vendor=\"Red Hat, Inc.\"       release=\"${RELEASE_VERSION}\"       io.openshift.expose-services=\"\"       io.openshift.build.commit.id=\"${COMMIT_SHA}\"       io.openshift.build.source-location=\"${SOURCE_URL}\"       io.openshift.build.commit.url=\"${SOURCE_URL}/commit/${COMMIT_SHA}\"       io.openshift.maintainer.product=\"OpenShift Container Platform\"       io.openshift.tags=\"data,images,operator,cert-manager\"       io.k8s.display-name=\"openshift-cert-manager-operator\"       io.k8s.description=\"cert-manager-operator-container\"",
```