### PR TITLE
CM-769,CM-770: Updates image sha of bundle in the catalogs

### DIFF
--- a/catalogs/v4.17/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.17/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
-      createdAt: 2025-10-31T06:17:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+      createdAt: 2025-11-05T09:53:21
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver

--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
-      createdAt: 2025-10-31T06:17:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+      createdAt: 2025-11-05T09:53:21
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
-      createdAt: 2025-10-31T06:17:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+      createdAt: 2025-11-05T09:53:21
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
-      createdAt: 2025-10-31T06:17:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+      createdAt: 2025-11-05T09:53:21
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
-      createdAt: 2025-10-31T06:17:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+      createdAt: 2025-11-05T09:53:21
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:d63f0b73e062f2227e452dc3dfc7853e60bbfbc13dcd64d65326889537b3539c
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f733b7737338fcac1a36e4c59a8854841d9e5d72e5d78b7857000afa2f0b830d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver


### PR DESCRIPTION
The PR is for updating the image sha of operator bundle in the 4.17-4.21 catalogs.

```
$ podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023...
Getting image source signatures
Copying blob c1bf9d520937 skipped: already exists  
Copying blob c6b5c16aa5da skipped: already exists  
Copying config b30b9c5396 done   | 
Writing manifest to image destination
b30b9c5396ebfef8da84a67c31e7f86a5f21d7181b45c1b2b59244d822c7a4f0
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023 | grep "io.openshift.build.commit.url"
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/4bc19d488c45b9cb84b0b333f8e5530c20d7dfbf",
               "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/4bc19d488c45b9cb84b0b333f8e5530c20d7dfbf",
                    "created_by": "/bin/sh -c #(nop) LABEL com.redhat.component=\"cert-manager-operator-bundle-container\"       name=\"cert-manager/cert-manager-operator-bundle\"       summary=\"Cert Manager support for OpenShift\"       description=\"Cert Manager support for OpenShift\"       distribution-scope=\"public\"       release=\"${RELEASE_VERSION}\"       version=\"${RELEASE_VERSION}\"       url=\"${SOURCE_URL}\"       maintainer=\"Red Hat, Inc.\"       vendor=\"Red Hat, Inc.\"       com.redhat.delivery.operator.bundle=true       com.redhat.openshift.versions=\"v4.17-v4.21\"       io.openshift.expose-services=\"\"       io.openshift.build.commit.id=\"${COMMIT_SHA}\"       io.openshift.build.source-location=\"${SOURCE_URL}\"       io.openshift.build.commit.url=\"${SOURCE_URL}/commit/${COMMIT_SHA}\"       io.openshift.maintainer.product=\"OpenShift Container Platform\"       io.openshift.tags=\"openshift,cert,cert-manager,cert-manager-operator,tls\"       io.k8s.display-name=\"openshift-cert-manager-operator-bundle\"       io.k8s.description=\"cert-manager-operator-bundle-container\"       operators.operatorframework.io.bundle.mediatype.v1=\"registry+v1\"       operators.operatorframework.io.bundle.manifests.v1=manifests/       operators.operatorframework.io.bundle.metadata.v1=metadata/       operators.operatorframework.io.bundle.package.v1=\"openshift-cert-manager-operator\"       operators.operatorframework.io.bundle.channel.default.v1=\"stable-v1\"       operators.operatorframework.io.bundle.channels.v1=\"stable-v1,stable-v1.18\"       operators.operatorframework.io.metrics.builder=\"operator-sdk-v1.25.1\"       operators.operatorframework.io.metrics.mediatype.v1=\"metrics+v1\"       operators.operatorframework.io.metrics.project_layout=\"go.kubebuilder.io/v3\"",
```