### PR TITLE
CM-772: [release-1.18] Update cert-manager-operator image reference for new stage

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,7 +8,7 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594 \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911 \
     CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
     CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \
     CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:cfcb30d5e2a1f11330ebb0332fbd7d009f804cadaa1eea56f72b2008a707fc57 \


### PR DESCRIPTION
The PR is for updating the sha of cert-manager-operator to the latest in bundle manifests

```sh
> podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911...
Getting image source signatures
Copying blob sha256:b175fac901a3d0e4e6c1104ee5fd1a59eaae4ee0751c262f9b6e9bcb8d98db8c
Copying blob sha256:8f7645d699153f67285998d904090d9a9bbd97961eedb7973b91ca460f3850c5
Copying config sha256:4531a9a6feaea95f2a7dc7e6b61b23b4a8d017300719c724bf6e99d01452b156
Writing manifest to image destination
4531a9a6feaea95f2a7dc7e6b61b23b4a8d017300719c724bf6e99d01452b156
```

```sh
> podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911 | grep "io.openshift.build.commit.url"

                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/d1085a83f8af5fe6d153b0d41f73e05533699459",
               "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/d1085a83f8af5fe6d153b0d41f73e05533699459",
                    "created_by": "/bin/sh -c #(nop) LABEL com.redhat.component=\"cert-manager-operator-container\"       name=\"cert-manager/cert-manager-operator-rhel9\"       version=\"${RELEASE_VERSION}\"       summary=\"cert-manager-operator\"       maintainer=\"Red Hat, Inc.\"       description=\"cert-manager-operator-container\"       vendor=\"Red Hat, Inc.\"       release=\"${RELEASE_VERSION}\"       io.openshift.expose-services=\"\"       io.openshift.build.commit.id=\"${COMMIT_SHA}\"       io.openshift.build.source-location=\"${SOURCE_URL}\"       io.openshift.build.commit.url=\"${SOURCE_URL}/commit/${COMMIT_SHA}\"       io.openshift.maintainer.product=\"OpenShift Container Platform\"       io.openshift.tags=\"data,images,operator,cert-manager\"       io.k8s.display-name=\"openshift-cert-manager-operator\"       io.k8s.description=\"cert-manager-operator-container\"",
```