### PR TITLE
CM-772: Update FBC catalogs in v4.17-v4.21 for v1.18.0 staging release

### DIFF
--- a/catalogs/v4.17/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.17/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
-      createdAt: 2025-11-05T09:53:21
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
+      createdAt: 2025-11-10T15:56:29
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver

--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
-      createdAt: 2025-11-05T09:53:21
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
+      createdAt: 2025-11-10T15:56:29
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
-      createdAt: 2025-11-05T09:53:21
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
+      createdAt: 2025-11-10T15:56:29
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
-      createdAt: 2025-11-05T09:53:21
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
+      createdAt: 2025-11-10T15:56:29
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.18.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
 name: cert-manager-operator.v1.18.0
 package: openshift-cert-manager-operator
 properties:
@@ -286,8 +286,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
-      createdAt: 2025-11-05T09:53:21
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
+      createdAt: 2025-11-10T15:56:29
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -423,9 +423,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:3c6ba8179791cdf683a26adfdc12c39ca93d663b6916d306bea0cf0920efa3c7
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fb0500fad940eb7ef1a7260fb9046c8e1037744c831df5091b00b563cf09e023
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fb599722d1b61770b302efe714beeda65a6fe1fcd7124d74eb5a2cd510468594
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911
   name: ""
 - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1895f1e3887cd8a5d9759304dd116ccc155517a21f06c1c098b64cd96e4d6519
   name: cert-manager-acmesolver


### PR DESCRIPTION
Update FBC catalogs for 4.17-4.21 for v1.18.0 release.

Using https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cert-manager-oape-tenant/applications/cert-manager-operator-1-18/releases/cert-manager-operator-1-18-vvj4v-f70182e-4lnfg/artifacts

```sh
> podman pull --arch amd64 registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22...
Getting image source signatures
Copying blob sha256:cc3c7d72924591862e24e2f84a4a55275f8d65ae3ca086d0e9d1b35652ec3d89
Copying blob sha256:c6b5c16aa5da01533fc599c8650989acdf061fc1c83a9166ddd6dc3fb3c06718
Copying config sha256:6b7807715fb8beb256699a970ed26301aecb269c65c9d0b6b7ae114ea7c050f8
Writing manifest to image destination
6b7807715fb8beb256699a970ed26301aecb269c65c9d0b6b7ae114ea7c050f8
```

```sh
> podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:0fabfe4aac6171525da65a64e34bc3de76011ffadbeb2278591c6ba87274ef22 | grep "io.openshift.build.commit.url"
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/f70182e6951b620c9907bd8593caac16fa1f144a",
               "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/f70182e6951b620c9907bd8593caac16fa1f144a",
                    "created_by": "/bin/sh -c #(nop) LABEL com.redhat.component=\"cert-manager-operator-bundle-container\"       name=\"cert-manager/cert-manager-operator-bundle\"       summary=\"Cert Manager support for OpenShift\"       description=\"Cert Manager support for OpenShift\"       distribution-scope=\"public\"       release=\"${RELEASE_VERSION}\"       version=\"${RELEASE_VERSION}\"       url=\"${SOURCE_URL}\"       maintainer=\"Red Hat, Inc.\"       vendor=\"Red Hat, Inc.\"       com.redhat.delivery.operator.bundle=true       com.redhat.openshift.versions=\"v4.17-v4.21\"       io.openshift.expose-services=\"\"       io.openshift.build.commit.id=\"${COMMIT_SHA}\"       io.openshift.build.source-location=\"${SOURCE_URL}\"       io.openshift.build.commit.url=\"${SOURCE_URL}/commit/${COMMIT_SHA}\"       io.openshift.maintainer.product=\"OpenShift Container Platform\"       io.openshift.tags=\"openshift,cert,cert-manager,cert-manager-operator,tls\"       io.k8s.display-name=\"openshift-cert-manager-operator-bundle\"       io.k8s.description=\"cert-manager-operator-bundle-container\"       operators.operatorframework.io.bundle.mediatype.v1=\"registry+v1\"       operators.operatorframework.io.bundle.manifests.v1=manifests/       operators.operatorframework.io.bundle.metadata.v1=metadata/       operators.operatorframework.io.bundle.package.v1=\"openshift-cert-manager-operator\"       operators.operatorframework.io.bundle.channel.default.v1=\"stable-v1\"       operators.operatorframework.io.bundle.channels.v1=\"stable-v1,stable-v1.18\"       operators.operatorframework.io.metrics.builder=\"operator-sdk-v1.25.1\"       operators.operatorframework.io.metrics.mediatype.v1=\"metrics+v1\"       operators.operatorframework.io.metrics.project_layout=\"go.kubebuilder.io/v3\"",
```