### PR TITLE
CM-792: Updates 1.15.2 stage images in bundle

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,11 +8,11 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:f328263e2d29e34ede65e4501f0447b2d9f84e9445a365c2fa2fbb253939e274 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6af3ee8b2a5a87042fb7158bda8d6cf2e6324d1e265974acf77214d4cd0ea0d3 \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6af3ee8b2a5a87042fb7158bda8d6cf2e6324d1e265974acf77214d4cd0ea0d3 \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6af3ee8b2a5a87042fb7158bda8d6cf2e6324d1e265974acf77214d4cd0ea0d3 \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:20efff60a0caf5eafb38986fd21611697b5bc534c2e789da233983a9739938ed \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:09edb16e872b1c927f17588b967d3593221680e6f0c66ae043dca968465a6beb \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321 \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321 \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321 \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1e8f10702c95bee8e2c78013a23f98674324ceb4fa7cbaab1d72e27d6fe17970 \
     CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9573d74bd2b926ec94af76f813e6358f14c5b2f4e0eedab7c1ff1070b7279a5c
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl


### PR DESCRIPTION
PR is for updating the staged image sha of 1.15.2 release in bundle

```
$ podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:09edb16e872b1c927f17588b967d3593221680e6f0c66ae043dca968465a6beb
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:09edb16e872b1c927f17588b967d3593221680e6f0c66ae043dca968465a6beb...
Getting image source signatures
Copying blob b9c8469709c0 skipped: already exists  
Copying blob 11b3f1cdbfd3 skipped: already exists  
Copying config a2809368d1 done   | 
Writing manifest to image destination
a2809368d1f077c67aa9b83ac1c1e873935885f008e6c7a76ae2a16b79da1562
```

```
 podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:09edb16e872b1c927f17588b967d3593221680e6f0c66ae043dca968465a6beb | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/957670bb7b848a705dbdf5135bf7056ba685b155",
```

```
$ podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321...
Getting image source signatures
Copying blob 22cc552e8348 skipped: already exists  
Copying blob 11b3f1cdbfd3 skipped: already exists  
Copying config 69c76e74e5 done   | 
Writing manifest to image destination
69c76e74e55bb88242710616df202d0d61181c28bfc522f1d88b820af3ad9882
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321 | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/957670bb7b848a705dbdf5135bf7056ba685b155",
```

```
$ podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1e8f10702c95bee8e2c78013a23f98674324ceb4fa7cbaab1d72e27d6fe17970
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1e8f10702c95bee8e2c78013a23f98674324ceb4fa7cbaab1d72e27d6fe17970...
Getting image source signatures
Copying blob 11b3f1cdbfd3 skipped: already exists  
Copying blob 3c7621b57e24 skipped: already exists  
Copying config 408174f83d done   | 
Writing manifest to image destination
408174f83d29df536c584939193aa22bb31dd804edaad86ae9f9c83ef18de167
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1e8f10702c95bee8e2c78013a23f98674324ceb4fa7cbaab1d72e27d6fe17970 | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/957670bb7b848a705dbdf5135bf7056ba685b155",
```