### PR TITLE
CM-792: Updates latest 1.15.2 stage images in bundle

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,11 +8,11 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:09edb16e872b1c927f17588b967d3593221680e6f0c66ae043dca968465a6beb \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321 \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321 \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:85d3a28692d3760850d3145637ac7adc43e81c33c6788f71e10e373f43d26321 \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1e8f10702c95bee8e2c78013a23f98674324ceb4fa7cbaab1d72e27d6fe17970 \
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:7c91cda4ad5b62f1f1bad8466fa94f54d0c5ab82296f2e8e22bf87d996f6c40e \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:76fe0671c410cb063225ecfa51c30f86634518a48757ee69bd2662f0643b5f40 \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:76fe0671c410cb063225ecfa51c30f86634518a48757ee69bd2662f0643b5f40 \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:76fe0671c410cb063225ecfa51c30f86634518a48757ee69bd2662f0643b5f40 \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:80d9e21cee7578e80ef80628436c5ce0d7af3118d161a196c31b8b1825e04dc7 \
     CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9573d74bd2b926ec94af76f813e6358f14c5b2f4e0eedab7c1ff1070b7279a5c
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl


### PR DESCRIPTION
```
$ podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:7c91cda4ad5b62f1f1bad8466fa94f54d0c5ab82296f2e8e22bf87d996f6c40e
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:7c91cda4ad5b62f1f1bad8466fa94f54d0c5ab82296f2e8e22bf87d996f6c40e...
Getting image source signatures
Copying blob ee02f3f0a07a skipped: already exists  
Copying blob 11b3f1cdbfd3 skipped: already exists  
Copying config b0fdf40392 done   | 
Writing manifest to image destination
b0fdf403927646ff18364986677acf31ff437efa459a34e630dae1a506995929
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:7c91cda4ad5b62f1f1bad8466fa94f54d0c5ab82296f2e8e22bf87d996f6c40e | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/af81b3743842c10a99ec01c0747fedaf1cde9715",
```

```
$ podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:76fe0671c410cb063225ecfa51c30f86634518a48757ee69bd2662f0643b5f40
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:76fe0671c410cb063225ecfa51c30f86634518a48757ee69bd2662f0643b5f40...
Getting image source signatures
Copying blob 5e20c2e93256 skipped: already exists  
Copying blob 11b3f1cdbfd3 skipped: already exists  
Copying config 478da867fd done   | 
Writing manifest to image destination
478da867fd31f8d8f686d68bc2b2b1dfb1f309d24689c627d2059e25d972a3f5
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:76fe0671c410cb063225ecfa51c30f86634518a48757ee69bd2662f0643b5f40 | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/af81b3743842c10a99ec01c0747fedaf1cde9715",
```

```
$ podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:80d9e21cee7578e80ef80628436c5ce0d7af3118d161a196c31b8b1825e04dc7
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:80d9e21cee7578e80ef80628436c5ce0d7af3118d161a196c31b8b1825e04dc7...
Getting image source signatures
Copying blob 4e22d673be33 skipped: already exists  
Copying blob 11b3f1cdbfd3 skipped: already exists  
Copying config 7332c03fda done   | 
Writing manifest to image destination
7332c03fda519106b4039ae8f8af0b4d2d3e6a0aca18ae0e7ccf2c3bad0abb30
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:80d9e21cee7578e80ef80628436c5ce0d7af3118d161a196c31b8b1825e04dc7 | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/af81b3743842c10a99ec01c0747fedaf1cde9715",
```