### PR TITLE
CM-850: Updates bundle with 1.18.1 staged images digest

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,12 +8,12 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:29a0fa1c2f2a6cee62a0468a3883d16d491b4af29130dad6e3e2bb2948f274df \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:29a0fa1c2f2a6cee62a0468a3883d16d491b4af29130dad6e3e2bb2948f274df \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:29a0fa1c2f2a6cee62a0468a3883d16d491b4af29130dad6e3e2bb2948f274df \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:ba937fc4b9eee31422914352c11a45b90754ba4fbe490ea45249b90afdc4e0a7 \
-    CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:af1ac813b8ee414ef215936f05197bc498bccbd540f3e2a93cb522221ba112bc
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926 \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971 \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971 \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971 \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52 \
+    CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime


### PR DESCRIPTION
Updates the staged image digests of 1.18.1 release.

```
$ podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926...
Getting image source signatures
Copying blob 5d00173c30ca skipped: already exists  
Copying blob 46a9484471e5 skipped: already exists  
Copying config 8d07a192fb done   | 
Writing manifest to image destination
8d07a192fb2bdd7c60348f396689d1445736bac63ff902b1a1923c589ee81c04
```
```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926 | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/13113165578ff289ae69ec287fea3aedd95134c4",
```


```
$ podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971...
Getting image source signatures
Copying blob a4adbd4da5ef skipped: already exists  
Copying blob 46a9484471e5 skipped: already exists  
Copying config 87fe2150a0 done   | 
Writing manifest to image destination
87fe2150a0be3089349fa5860e0bd14b26626223756e8181a20d5ac31cb18cc2
```
```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971 | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/13113165578ff289ae69ec287fea3aedd95134c4",
```


```
$ podman pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52
Trying to pull registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52...
Getting image source signatures
Copying blob c9ddcd664eab skipped: already exists  
Copying blob 46a9484471e5 skipped: already exists  
Copying config 3583450a8b done   | 
Writing manifest to image destination
3583450a8b077ed25716e7b00fda5654cda5b909a5298a433da9397c811416a4
```
```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52 | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/13113165578ff289ae69ec287fea3aedd95134c4",
```


```
$ podman pull registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb...
Getting image source signatures
Copying blob 54040b4e4860 skipped: already exists  
Copying blob 46a9484471e5 skipped: already exists  
Copying config 02cf4839bf done   | 
Writing manifest to image destination
02cf4839bfe7e038f58b15844aa8767a5209c81777b0d2995129e16b24d5f0dc
```
```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/13113165578ff289ae69ec287fea3aedd95134c4",
```