### PR TITLE
CM-850: Updates 1.18.1 staged bundle image in 4.17-4.21 catalogs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ build-catalog-image:
 ## update catalog using the provided bundle image.
 .PHONY: update-catalog
 update-catalog: get-opm
-	# Ex: make update-catalog OPERATOR_BUNDLE_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:4114321b0ab6ceb882f26501ff9b22214d90b83d92466e7c5a62217f592c1fed CATALOG_DIR=catalogs/v4.17/catalog BUNDLE_FILE_NAME=bundle-v1.15.0.yaml REPLICATE_BUNDLE_FILE_IN_CATALOGS=no USE_MIGRATE_LEVEL_FLAG=yes
+	@# Ex: make update-catalog OPERATOR_BUNDLE_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:4114321b0ab6ceb882f26501ff9b22214d90b83d92466e7c5a62217f592c1fed CATALOG_DIR=catalogs/v4.17/catalog BUNDLE_FILE_NAME=bundle-v1.15.0.yaml REPLICATE_BUNDLE_FILE_IN_CATALOGS=no USE_MIGRATE_LEVEL_FLAG=yes
 	./hack/update_catalog.sh $(OPM_TOOL_PATH) $(OPERATOR_BUNDLE_IMAGE) $(CATALOG_DIR) $(BUNDLE_FILE_NAME) $(REPLICATE_BUNDLE_FILE_IN_CATALOGS) $(USE_MIGRATE_LEVEL_FLAG)
 
 ## update catalog and build catalog image.

--- a/catalogs/v4.17/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
+++ b/catalogs/v4.17/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
@@ -1,0 +1,438 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+name: cert-manager-operator.v1.18.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.18.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "selfsigned-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "selfsigned-issuer"
+            },
+            "spec": {
+              "selfSigned": {}
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+      createdAt: 2026-01-09T09:17:52
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.18.0 <1.18.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.18.4](https://github.com/cert-manager/cert-manager/tree/v1.18.4), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.27.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.17/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.17/catalog/openshift-cert-manager-operator/channel.yaml
@@ -26,6 +26,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -147,6 +150,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1.18
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
@@ -1,0 +1,438 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+name: cert-manager-operator.v1.18.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.18.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "selfsigned-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "selfsigned-issuer"
+            },
+            "spec": {
+              "selfSigned": {}
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+      createdAt: 2026-01-09T09:17:52
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.18.0 <1.18.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.18.4](https://github.com/cert-manager/cert-manager/tree/v1.18.4), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.27.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/channel.yaml
@@ -20,6 +20,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -103,6 +106,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1.18
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
@@ -1,0 +1,438 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+name: cert-manager-operator.v1.18.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.18.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "selfsigned-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "selfsigned-issuer"
+            },
+            "spec": {
+              "selfSigned": {}
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+      createdAt: 2026-01-09T09:17:52
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.18.0 <1.18.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.18.4](https://github.com/cert-manager/cert-manager/tree/v1.18.4), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.27.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
@@ -20,6 +20,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -103,6 +106,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1.18
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
@@ -1,0 +1,438 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+name: cert-manager-operator.v1.18.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.18.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "selfsigned-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "selfsigned-issuer"
+            },
+            "spec": {
+              "selfSigned": {}
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+      createdAt: 2026-01-09T09:17:52
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.18.0 <1.18.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.18.4](https://github.com/cert-manager/cert-manager/tree/v1.18.4), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.27.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/channel.yaml
@@ -6,6 +6,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -25,6 +28,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1.18
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.18.1.yaml
@@ -1,0 +1,438 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+name: cert-manager-operator.v1.18.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.18.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "selfsigned-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "selfsigned-issuer"
+            },
+            "spec": {
+              "selfSigned": {}
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+      createdAt: 2026-01-09T09:17:52
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.18.0 <1.18.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.18.4](https://github.com/cert-manager/cert-manager/tree/v1.18.4), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.27.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/channel.yaml
@@ -3,6 +3,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -11,6 +14,9 @@ entries:
 - name: cert-manager-operator.v1.18.0
   replaces: cert-manager-operator.v1.17.0
   skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
 name: stable-v1.18
 package: openshift-cert-manager-operator
 schema: olm.channel


### PR DESCRIPTION
The PR is for updating 1.18.1 staged bundle image in OCP 4.17 - 4.21 catalogs.

```
$ podman pull registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e
Trying to pull registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e...
Getting image source signatures
Copying blob fab79d103b1e skipped: already exists  
Copying blob 46a9484471e5 skipped: already exists  
Copying config bc37c1784f done   | 
Writing manifest to image destination
bc37c1784fd8e3afc8a8e1f0d4ec8598d831ea22442c9adf362909fa5cbfc708
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb16cd789bb894812819490e3c49e4d8dd352edb31829719cbfc8fd2a2a4938e | grep "io.openshift.build.commit.url" -m1
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/1113d0c8a1faaf88e2ad8a0c072e83bdb75ff8b9",
```