### PR TITLE
CM-844: Set cpe label for 1.18 components

### DIFF
--- a/Containerfile.cert-manager
+++ b/Containerfile.cert-manager
@@ -34,6 +34,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="jetstack-cert-manager-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.18::el9" \
       name="cert-manager/jetstack-cert-manager-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager" \

--- a/Containerfile.cert-manager-istio-csr
+++ b/Containerfile.cert-manager-istio-csr
@@ -29,6 +29,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="cert-manager-istio-csr-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.18::el9" \
       name="cert-manager/cert-manager-istio-csr-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager-istio-csr" \

--- a/Containerfile.cert-manager-operator
+++ b/Containerfile.cert-manager-operator
@@ -25,6 +25,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="cert-manager-operator-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.18::el9" \
       name="cert-manager/cert-manager-operator-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager-operator" \

--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -38,6 +38,7 @@ ARG SOURCE_URL
 
 # Core bundle labels.
 LABEL com.redhat.component="cert-manager-operator-bundle-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.18::el9" \
       name="cert-manager/cert-manager-operator-bundle" \
       summary="Cert Manager support for OpenShift" \
       description="Cert Manager support for OpenShift" \

--- a/Containerfile.cert-manager.acmesolver
+++ b/Containerfile.cert-manager.acmesolver
@@ -35,6 +35,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="jetstack-cert-manager-acmesolver-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.18::el9" \
       name="cert-manager/jetstack-cert-manager-acmesolver-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager-acmesolver" \


### PR DESCRIPTION
For [KONFLUX-6210](https://issues.redhat.com/browse/KONFLUX-6210), clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

This is enforced in release flow, and the release fails if required labels are not present.
```
  + name=cert-manager-istio-csr-1-18
  ++ jq -r '.metadata.labels // [] | .[] | select(.name == "cpe")
          | .value // empty'
  + cpe_label=cpe:/a:redhat:enterprise_linux:9::appstream
  + [[ -z cpe:/a:redhat:enterprise_linux:9::appstream ]]
  + [[ cpe:/a:redhat:enterprise_linux:9::appstream != \c\p\e\:\/\a\:\r\e\d\h\a\t\:\c\e\r\t\_\m\a\n\a\g\e\r\:\1\.\1\8\:\:\e\l\9 ]]
  + fail_or_warn 'Component '\''cert-manager-istio-csr-1-18'\'' '\''cpe'\'' label ('\''cpe:/a:redhat:enterprise_linux:9::appstream'\'') does not match' 'the single required CPE value from the data file ('\''cpe:/a:redhat:cert_manager:1.18::el9'\'').'
  + local 'msg=Component '\''cert-manager-istio-csr-1-18'\'' '\''cpe'\'' label ('\''cpe:/a:redhat:enterprise_linux:9::appstream'\'') does not match the single required CPE value from the data file ('\''cpe:/a:redhat:cert_manager:1.18::el9'\'').'
  + '[' true == true ']'
  + echo 'Error: Component '\''cert-manager-istio-csr-1-18'\'' '\''cpe'\'' label ('\''cpe:/a:redhat:enterprise_linux:9::appstream'\'') does not match the single required CPE value from the data file ('\''cpe:/a:redhat:cert_manager:1.18::el9'\'').'
  Error: Component 'cert-manager-istio-csr-1-18' 'cpe' label ('cpe:/a:redhat:enterprise_linux:9::appstream') does not match the single required CPE value from the data file ('cpe:/a:redhat:cert_manager:1.18::el9').
```

See also
- https://github.com/release-engineering/rhtap-ec-policy/pull/149
- https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/13312
- https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/13313