### PR TITLE
CM-844: Updates bundle with 1.18.1 prod images digest

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,12 +8,12 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a7b757323bfb771be3afc6aadb9b65bcb7fed89e3b8ec386b0cca62936570926 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971 \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971 \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:956357c599a3dda3b717222df29f0d74c9303ce7fa4ebb9ef5958a095ac1f971 \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:a5a8e198b18799fe56d9b1ce4e01dded94be235a6b03bc21086252653ae57a52 \
-    CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a4bc5398c3f6241a85e84c6c425f1b9fec48d46caaad1d579d093f26c486a6bb
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:9cee274a2641344a415b5e5ae6f877ea7afad84a70e51172bcb2091e7c34d754 \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:b88eaa1d06c6ef00b1a2a3ff6e8f3fa394c59c0e10f8ff09a40a73c33a7cdefd \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:b88eaa1d06c6ef00b1a2a3ff6e8f3fa394c59c0e10f8ff09a40a73c33a7cdefd \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:b88eaa1d06c6ef00b1a2a3ff6e8f3fa394c59c0e10f8ff09a40a73c33a7cdefd \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1ea1f60dc7c25ec41863d8f173ed3a754208574dc540180adc312b157d42b5a5 \
+    CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:20de32b9dc76d7d6f2951f8409385501801919992c224bd19c9e6e3694f7daef
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime


### PR DESCRIPTION
Updates the prod image digests of 1.18.1 release.

```
$ podman pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:9cee274a2641344a415b5e5ae6f877ea7afad84a70e51172bcb2091e7c34d754
Trying to pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:9cee274a2641344a415b5e5ae6f877ea7afad84a70e51172bcb2091e7c34d754...
Getting image source signatures
Copying blob 8dcc03d1ea73 skipped: already exists  
Copying blob 8369c500d2f3 skipped: already exists  
Copying config f08bb39f4b done   | 
Writing manifest to image destination
f08bb39f4ba66d7b28876be96f526cf06cc7496de8a8d8f11ce315a2d94c9112
```
```
$ podman inspect registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:9cee274a2641344a415b5e5ae6f877ea7afad84a70e51172bcb2091e7c34d754 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/1eb77276223abe2a8e2d19dd23d7a7835c22f2bb",
                    "version": "v1.18.1"
```

```
$ podman pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:b88eaa1d06c6ef00b1a2a3ff6e8f3fa394c59c0e10f8ff09a40a73c33a7cdefd
Trying to pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:b88eaa1d06c6ef00b1a2a3ff6e8f3fa394c59c0e10f8ff09a40a73c33a7cdefd...
Getting image source signatures
Copying blob d04999b4daf8 skipped: already exists  
Copying blob 8369c500d2f3 skipped: already exists  
Copying config ddd1fa4036 done   | 
Writing manifest to image destination
ddd1fa4036c4dc0a880bb571d9fbc174c8ed5f85460e875b3ed6ff758d931ee8
```
```
$ podman inspect registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:b88eaa1d06c6ef00b1a2a3ff6e8f3fa394c59c0e10f8ff09a40a73c33a7cdefd | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/1eb77276223abe2a8e2d19dd23d7a7835c22f2bb",
                    "version": "v1.18.4"
```

```
$ podman pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1ea1f60dc7c25ec41863d8f173ed3a754208574dc540180adc312b157d42b5a5
Trying to pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1ea1f60dc7c25ec41863d8f173ed3a754208574dc540180adc312b157d42b5a5...
Getting image source signatures
Copying blob 70bf74adcf65 skipped: already exists  
Copying blob 8369c500d2f3 skipped: already exists  
Copying config a3ddb3c43c done   | 
Writing manifest to image destination
a3ddb3c43cda2888364b47b86fea97316b521383934249a3a2d42d92483ebba2
```
```
$ podman inspect registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:1ea1f60dc7c25ec41863d8f173ed3a754208574dc540180adc312b157d42b5a5 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/1eb77276223abe2a8e2d19dd23d7a7835c22f2bb",
                    "version": "v1.18.4"
```

```
$ podman pull registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:20de32b9dc76d7d6f2951f8409385501801919992c224bd19c9e6e3694f7daef
Trying to pull registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:20de32b9dc76d7d6f2951f8409385501801919992c224bd19c9e6e3694f7daef...
Getting image source signatures
Copying blob 58859fc5a854 skipped: already exists  
Copying blob 8369c500d2f3 skipped: already exists  
Copying config 0998bc1f63 done   | 
Writing manifest to image destination
0998bc1f634f4b1a1a9fc0353f866f79a793c2e3157d968cc0d3fad5295b90e7
```
```
$ podman inspect registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:20de32b9dc76d7d6f2951f8409385501801919992c224bd19c9e6e3694f7daef | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/1eb77276223abe2a8e2d19dd23d7a7835c22f2bb",
                    "version": "v0.14.2"
```