### PR TITLE
CM-779: Updates bundle with 1.19.0 staged images digest

### DIFF
--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -8,12 +8,12 @@ COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
 
 # Below image versions are used for replacing the image references in the operator CSV.
 # For image builds through konflux, konflux-bot will update the references.
-ARG CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:fa8de363ab4435c1085ac37f1bad488828c6ae8ba361c5f865c27ef577610911 \
-    CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:29a0fa1c2f2a6cee62a0468a3883d16d491b4af29130dad6e3e2bb2948f274df \
-    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:29a0fa1c2f2a6cee62a0468a3883d16d491b4af29130dad6e3e2bb2948f274df \
-    CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:29a0fa1c2f2a6cee62a0468a3883d16d491b4af29130dad6e3e2bb2948f274df \
-    CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:ba937fc4b9eee31422914352c11a45b90754ba4fbe490ea45249b90afdc4e0a7 \
-    CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:af1ac813b8ee414ef215936f05197bc498bccbd540f3e2a93cb522221ba112bc
+ARG CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433 \
+    CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc \
+    CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc \
+    CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc \
+    CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:e2499fe2ca342f7f89e55fc36b7b4d7ae60286bce6cca69dc32e5549b26c5459 \
+    CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime


### PR DESCRIPTION
The PR is for updating the bundle with 1.19.0 staged images digest.

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/6cab7ba8127b04f544ab01b17405cf5af4375e4d",
                    "version": "v1.19.0"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/6cab7ba8127b04f544ab01b17405cf5af4375e4d",
                    "version": "v1.19.2"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:e2499fe2ca342f7f89e55fc36b7b4d7ae60286bce6cca69dc32e5549b26c5459 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/6cab7ba8127b04f544ab01b17405cf5af4375e4d",
                    "version": "v1.19.2"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/6cab7ba8127b04f544ab01b17405cf5af4375e4d",
                    "version": "v0.15.0"
```