### PR TITLE
CM-865: Updates trust-manager staged image digest in the bundle

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -22,4 +22,4 @@ CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cer
 CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
 
 # cert-manager trust-manager operand image digest.
-TRUST_MANAGER_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
+TRUST_MANAGER_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:0c91e1567a4fa7cb1a2b87bb664f39399a01516bf9adff2cc3ed96fdeed6186c


### PR DESCRIPTION
The PR is for updating the trust-manager staged image digest in the bundle. This is the first published image of trust-manager, the PR is replacing the old dummy digest added.

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:0c91e1567a4fa7cb1a2b87bb664f39399a01516bf9adff2cc3ed96fdeed6186c | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/141a4d4871c0b5f26ecbd2c4d728da8feb057b31",
                    "version": "v0.20.3"
```