### PR TITLE
CM-904: Updates latest image sha in the bundle

### DIFF
--- a/hack/bundle/render_templates.sh
+++ b/hack/bundle/render_templates.sh
@@ -27,7 +27,7 @@ update_csv_manifest() {
 		-e "s#quay.io/jetstack/cert-manager-cainjector.*#${CERT_MANAGER_CA_INJECTOR_IMAGE}#g" \
 		-e "s#quay.io/jetstack/cert-manager-acmesolver.*#${CERT_MANAGER_ACMESOLVER_IMAGE}#g" \
 		-e "s#quay.io/jetstack/cert-manager-istio-csr.*#${CERT_MANAGER_ISTIOCSR_IMAGE}#g" \
-		-e "s#quay.io/jetstack/trust-manager.*#${TRUST_MANAGER_IMAGE}#g" \
+		-e "s#quay.io/jetstack/trust-manager.*#${CERT_MANAGER_TRUST_MANAGER_IMAGE}#g" \
 		"${csv_file}"
 
 	## update annotations in CSV manifest.
@@ -81,7 +81,7 @@ required_images=(
 	CERT_MANAGER_CONTROLLER_IMAGE
 	CERT_MANAGER_ACMESOLVER_IMAGE
 	CERT_MANAGER_ISTIOCSR_IMAGE
-	TRUST_MANAGER_IMAGE
+	CERT_MANAGER_TRUST_MANAGER_IMAGE
 )
 
 for img_var in "${required_images[@]}"; do

--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,22 +4,22 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # cert-manager operator image digest.
-CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
+CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
 
 # cert-manager operand - webhook component image digest.
-CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
 
 # cert-manager operand - cainjector component image digest.
-CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
 
 # cert-manager operand - controller component image digest.
-CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
 
 # cert-manager operand - acmesolver component image digest.
-CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:e2499fe2ca342f7f89e55fc36b7b4d7ae60286bce6cca69dc32e5549b26c5459
+CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
 
 # cert-manager-istiocsr operand image digest.
-CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
+CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
 
 # cert-manager trust-manager operand image digest.
-TRUST_MANAGER_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:0c91e1567a4fa7cb1a2b87bb664f39399a01516bf9adff2cc3ed96fdeed6186c
+CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d


### PR DESCRIPTION
The PR is for updating the operator bundle with latest image sha of operator and operand for 1.19.0 release.

```
 podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/2b8f47f5148cc09ecb8e8bb0959d81d00214f18f",
                    "version": "v1.19.0"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/2b8f47f5148cc09ecb8e8bb0959d81d00214f18f",
                    "version": "v1.19.4"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/2b8f47f5148cc09ecb8e8bb0959d81d00214f18f",
                    "version": "v1.19.4"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/2b8f47f5148cc09ecb8e8bb0959d81d00214f18f",
                    "version": "v0.16.0"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/c7e7ac7fedb1fc9884c1d245a3edb6ca2a735fae",
                    "version": "v0.20.3"
```