### PR TITLE
CM-904: Updates 1.19.0 stage bundle in 4.18-4.22 catalogs

### DIFF
--- a/catalogs/v4.18/Containerfile
+++ b/catalogs/v4.18/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -42,6 +42,16 @@ properties:
   value:
     group: operator.openshift.io
     kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
     version: v1alpha1
 - type: olm.package
   value:
@@ -128,7 +138,7 @@ properties:
               "issuerRef": {
                 "group": "cert-manager.io",
                 "kind": "ClusterIssuer",
-                "name": "selfsigned-issuer"
+                "name": "ca-cluster-issuer"
               },
               "privateKey": {
                 "algorithm": "ECDSA",
@@ -187,10 +197,12 @@ properties:
             "apiVersion": "cert-manager.io/v1",
             "kind": "ClusterIssuer",
             "metadata": {
-              "name": "selfsigned-issuer"
+              "name": "ca-cluster-issuer"
             },
             "spec": {
-              "selfSigned": {}
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
             }
           },
           {
@@ -281,13 +293,49 @@ properties:
                 }
               }
             }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
           }
         ]
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
-      createdAt: 2026-01-27T05:16:50
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+      createdAt: 2026-04-07T07:07:42
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -316,6 +364,12 @@ properties:
     apiServiceDefinitions: {}
     crdDescriptions:
       owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
       - description: |-
           A CertificateRequest is used to request a signed certificate from one of the
           configured issuers.
@@ -383,8 +437,16 @@ properties:
         kind: Order
         name: orders.acme.cert-manager.io
         version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
     description: |
-      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.2](https://github.com/cert-manager/cert-manager/tree/v1.19.2), which automates certificate management.
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.4](https://github.com/cert-manager/cert-manager/tree/v1.19.4), which automates certificate management.
       For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
     displayName: cert-manager Operator for Red Hat OpenShift
     installModes:
@@ -404,6 +466,7 @@ properties:
     - security
     - TLS
     - istio-csr
+    - trust-manager
     labels:
       operatorframework.io/arch.amd64: supported
       operatorframework.io/arch.arm64: supported
@@ -421,18 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
   name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:e2499fe2ca342f7f89e55fc36b7b4d7ae60286bce6cca69dc32e5549b26c5459
+- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.19/Containerfile
+++ b/catalogs/v4.19/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -42,6 +42,16 @@ properties:
   value:
     group: operator.openshift.io
     kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
     version: v1alpha1
 - type: olm.package
   value:
@@ -128,7 +138,7 @@ properties:
               "issuerRef": {
                 "group": "cert-manager.io",
                 "kind": "ClusterIssuer",
-                "name": "selfsigned-issuer"
+                "name": "ca-cluster-issuer"
               },
               "privateKey": {
                 "algorithm": "ECDSA",
@@ -187,10 +197,12 @@ properties:
             "apiVersion": "cert-manager.io/v1",
             "kind": "ClusterIssuer",
             "metadata": {
-              "name": "selfsigned-issuer"
+              "name": "ca-cluster-issuer"
             },
             "spec": {
-              "selfSigned": {}
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
             }
           },
           {
@@ -281,13 +293,49 @@ properties:
                 }
               }
             }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
           }
         ]
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
-      createdAt: 2026-01-27T05:16:50
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+      createdAt: 2026-04-07T07:07:42
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -316,6 +364,12 @@ properties:
     apiServiceDefinitions: {}
     crdDescriptions:
       owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
       - description: |-
           A CertificateRequest is used to request a signed certificate from one of the
           configured issuers.
@@ -383,8 +437,16 @@ properties:
         kind: Order
         name: orders.acme.cert-manager.io
         version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
     description: |
-      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.2](https://github.com/cert-manager/cert-manager/tree/v1.19.2), which automates certificate management.
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.4](https://github.com/cert-manager/cert-manager/tree/v1.19.4), which automates certificate management.
       For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
     displayName: cert-manager Operator for Red Hat OpenShift
     installModes:
@@ -404,6 +466,7 @@ properties:
     - security
     - TLS
     - istio-csr
+    - trust-manager
     labels:
       operatorframework.io/arch.amd64: supported
       operatorframework.io/arch.arm64: supported
@@ -421,18 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
   name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:e2499fe2ca342f7f89e55fc36b7b4d7ae60286bce6cca69dc32e5549b26c5459
+- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.20/Containerfile
+++ b/catalogs/v4.20/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -42,6 +42,16 @@ properties:
   value:
     group: operator.openshift.io
     kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
     version: v1alpha1
 - type: olm.package
   value:
@@ -128,7 +138,7 @@ properties:
               "issuerRef": {
                 "group": "cert-manager.io",
                 "kind": "ClusterIssuer",
-                "name": "selfsigned-issuer"
+                "name": "ca-cluster-issuer"
               },
               "privateKey": {
                 "algorithm": "ECDSA",
@@ -187,10 +197,12 @@ properties:
             "apiVersion": "cert-manager.io/v1",
             "kind": "ClusterIssuer",
             "metadata": {
-              "name": "selfsigned-issuer"
+              "name": "ca-cluster-issuer"
             },
             "spec": {
-              "selfSigned": {}
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
             }
           },
           {
@@ -281,13 +293,49 @@ properties:
                 }
               }
             }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
           }
         ]
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
-      createdAt: 2026-01-27T05:16:50
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+      createdAt: 2026-04-07T07:07:42
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -316,6 +364,12 @@ properties:
     apiServiceDefinitions: {}
     crdDescriptions:
       owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
       - description: |-
           A CertificateRequest is used to request a signed certificate from one of the
           configured issuers.
@@ -383,8 +437,16 @@ properties:
         kind: Order
         name: orders.acme.cert-manager.io
         version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
     description: |
-      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.2](https://github.com/cert-manager/cert-manager/tree/v1.19.2), which automates certificate management.
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.4](https://github.com/cert-manager/cert-manager/tree/v1.19.4), which automates certificate management.
       For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
     displayName: cert-manager Operator for Red Hat OpenShift
     installModes:
@@ -404,6 +466,7 @@ properties:
     - security
     - TLS
     - istio-csr
+    - trust-manager
     labels:
       operatorframework.io/arch.amd64: supported
       operatorframework.io/arch.arm64: supported
@@ -421,18 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
   name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:e2499fe2ca342f7f89e55fc36b7b4d7ae60286bce6cca69dc32e5549b26c5459
+- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.21/Containerfile
+++ b/catalogs/v4.21/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -42,6 +42,16 @@ properties:
   value:
     group: operator.openshift.io
     kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
     version: v1alpha1
 - type: olm.package
   value:
@@ -128,7 +138,7 @@ properties:
               "issuerRef": {
                 "group": "cert-manager.io",
                 "kind": "ClusterIssuer",
-                "name": "selfsigned-issuer"
+                "name": "ca-cluster-issuer"
               },
               "privateKey": {
                 "algorithm": "ECDSA",
@@ -187,10 +197,12 @@ properties:
             "apiVersion": "cert-manager.io/v1",
             "kind": "ClusterIssuer",
             "metadata": {
-              "name": "selfsigned-issuer"
+              "name": "ca-cluster-issuer"
             },
             "spec": {
-              "selfSigned": {}
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
             }
           },
           {
@@ -281,13 +293,49 @@ properties:
                 }
               }
             }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
           }
         ]
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
-      createdAt: 2026-01-27T05:16:50
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+      createdAt: 2026-04-07T07:07:42
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -316,6 +364,12 @@ properties:
     apiServiceDefinitions: {}
     crdDescriptions:
       owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
       - description: |-
           A CertificateRequest is used to request a signed certificate from one of the
           configured issuers.
@@ -383,8 +437,16 @@ properties:
         kind: Order
         name: orders.acme.cert-manager.io
         version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
     description: |
-      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.2](https://github.com/cert-manager/cert-manager/tree/v1.19.2), which automates certificate management.
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.4](https://github.com/cert-manager/cert-manager/tree/v1.19.4), which automates certificate management.
       For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
     displayName: cert-manager Operator for Red Hat OpenShift
     installModes:
@@ -404,6 +466,7 @@ properties:
     - security
     - TLS
     - istio-csr
+    - trust-manager
     labels:
       operatorframework.io/arch.amd64: supported
       operatorframework.io/arch.arm64: supported
@@ -421,18 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
   name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:e2499fe2ca342f7f89e55fc36b7b4d7ae60286bce6cca69dc32e5549b26c5459
+- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.22/Containerfile
+++ b/catalogs/v4.22/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -42,6 +42,16 @@ properties:
   value:
     group: operator.openshift.io
     kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
     version: v1alpha1
 - type: olm.package
   value:
@@ -128,7 +138,7 @@ properties:
               "issuerRef": {
                 "group": "cert-manager.io",
                 "kind": "ClusterIssuer",
-                "name": "selfsigned-issuer"
+                "name": "ca-cluster-issuer"
               },
               "privateKey": {
                 "algorithm": "ECDSA",
@@ -187,10 +197,12 @@ properties:
             "apiVersion": "cert-manager.io/v1",
             "kind": "ClusterIssuer",
             "metadata": {
-              "name": "selfsigned-issuer"
+              "name": "ca-cluster-issuer"
             },
             "spec": {
-              "selfSigned": {}
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
             }
           },
           {
@@ -281,13 +293,49 @@ properties:
                 }
               }
             }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
           }
         ]
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
-      createdAt: 2026-01-27T05:16:50
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+      createdAt: 2026-04-07T07:07:42
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -316,6 +364,12 @@ properties:
     apiServiceDefinitions: {}
     crdDescriptions:
       owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
       - description: |-
           A CertificateRequest is used to request a signed certificate from one of the
           configured issuers.
@@ -383,8 +437,16 @@ properties:
         kind: Order
         name: orders.acme.cert-manager.io
         version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
     description: |
-      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.2](https://github.com/cert-manager/cert-manager/tree/v1.19.2), which automates certificate management.
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.4](https://github.com/cert-manager/cert-manager/tree/v1.19.4), which automates certificate management.
       For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
     displayName: cert-manager Operator for Red Hat OpenShift
     installModes:
@@ -404,6 +466,7 @@ properties:
     - security
     - TLS
     - istio-csr
+    - trust-manager
     labels:
       operatorframework.io/arch.amd64: supported
       operatorframework.io/arch.arm64: supported
@@ -421,18 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1901472d7a69bf4f2d52432c341fb0500279bec18fb5acec5ab3e8edd73faa31
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:eb80d510be3b47a030736b48bb3a642801226955f8977bbe1e9845eb4e03ad5d
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:be1e0621083fb82a82321875988bc3efbd14b24349e48ffb1c2bbd4858257433
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
   name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:e2499fe2ca342f7f89e55fc36b7b4d7ae60286bce6cca69dc32e5549b26c5459
+- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:dfafd97d53c7c964aa19bd273aec4e437ec2b95ed5ec996ceb01819d2c91ccbc
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
   name: cert-manager-controller
 schema: olm.bundle


### PR DESCRIPTION
The PR is for updating the 1.19.0 latest staged bundle in OCP 4.18 to 4.22 catalogs.

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/5b5a77f694c48742e2cffe9cac353da248f39209",
                    "version": "v1.19.0"
```