### PR TITLE
NO-JIRA: Updates renovate config to include branch details in PR title

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
 	"assigneesFromCodeOwners": true,
 	"automergeStrategy": "auto",
 	"automergeType": "pr",
-	"commitMessagePrefix": "NO-JIRA: ",
+	"commitMessagePrefix": "[{{baseBranch}}] NO-JIRA: ",
 	"ignoreTests": false,
 	"rebaseLabel": "needs-rebase",
 	"rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
The PR is for updating the renovate config to include the base branch name in the created PR title like `[<base-branch>] NO-JIRA: ` to identify the branch against which the PR is created easily.