### PR TITLE
CM-786: Updates cert-manager-operator module to the latest commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "jetstack-cert-manager"]
 	path = cert-manager
 	url = https://github.com/openshift/jetstack-cert-manager.git
-	tag = release-1.19
+	branch = release-1.19
 [submodule "cert-manager-operator"]
 	path = cert-manager-operator
 	url = https://github.com/openshift/cert-manager-operator.git

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ## local variables.
 cert_manager_submodule_dir = cert-manager
-cert_manager_submodule_tag = $(strip $(shell git config -f .gitmodules submodule.jetstack-cert-manager.tag))
+cert_manager_submodule_branch = $(strip $(shell git config -f .gitmodules submodule.jetstack-cert-manager.branch))
 cert_manager_operator_submodule_dir = cert-manager-operator
 cert_manager_operator_submodule_branch = $(strip $(shell git config -f .gitmodules submodule.cert-manager-operator.branch))
 istio_csr_submodule_dir = cert-manager-istio-csr
@@ -18,8 +18,8 @@ source_url = $(strip $(shell git remote get-url origin))
 release_version = v$(strip $(shell git branch --show-current | cut -d'-' -f2))
 
 ## validate that tags and branches are not empty
-ifeq ($(cert_manager_submodule_tag),)
-$(error cert_manager_submodule_tag is empty.)
+ifeq ($(cert_manager_submodule_branch),)
+$(error cert_manager_submodule_branch is empty.)
 endif
 ifeq ($(cert_manager_operator_submodule_branch),)
 $(error cert_manager_operator_submodule_branch is empty.)
@@ -93,7 +93,7 @@ switch-submodules-branch:
 .PHONY: update-submodules
 update-submodules:
 	git submodule foreach --recursive 'git fetch -t'
-	cd $(cert_manager_submodule_dir) && git checkout $(cert_manager_submodule_tag) && cd - > /dev/null
+	cd $(cert_manager_submodule_dir) && git checkout $(cert_manager_submodule_branch) && cd - > /dev/null
 	cd $(istio_csr_submodule_dir) && git checkout $(istio_csr_submodule_tag) && cd - > /dev/null
 	cd $(trust_manager_submodule_dir) && git checkout $(trust_manager_submodule_tag) && cd - > /dev/null
 	cd $(cert_manager_operator_submodule_dir) && git checkout $(cert_manager_operator_submodule_branch) && git pull origin $(cert_manager_operator_submodule_branch) && cd - > /dev/null


### PR DESCRIPTION
The PR is for updating the `cert-manager-operator` git submodule to the latest commit and also updates the `cert-manager` git module config to use branch and also the Makefile accordingly.