### PR TITLE
CM-786: Updates latest staged cert-manager-operator bundle image sha in catalogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 cert-manager/
 cert-manager-operator/
 cert-manager-istio-csr/
+trust-manager/

--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
-      createdAt: 2026-04-07T07:07:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-15T09:44:09
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -486,9 +486,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
 - image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
   name: cert-manager-trust-manager

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
-      createdAt: 2026-04-07T07:07:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-15T09:44:09
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -486,9 +486,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
 - image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
   name: cert-manager-trust-manager

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
-      createdAt: 2026-04-07T07:07:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-15T09:44:09
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -486,9 +486,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
 - image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
   name: cert-manager-trust-manager

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
-      createdAt: 2026-04-07T07:07:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-15T09:44:09
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -486,9 +486,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
 - image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
   name: cert-manager-trust-manager

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
-      createdAt: 2026-04-07T07:07:42
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-15T09:44:09
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -486,9 +486,9 @@ properties:
 relatedImages:
 - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:449c6152e1d43279ca4534bd5115c82788130d40efd0d521744d4f8c5c6a2b69
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:0ba1c9ac0801461b53aea60d2021561e5d611a18a66265e52d9f17e70253136b
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
 - image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
   name: cert-manager-trust-manager


### PR DESCRIPTION
The PR is for updating the latest staged bundle image sha in 4.18 - 4.22 OCP catalogs and also adds `trust-manager` git submodule to `.gitignore` in main branch where git modules are not used.

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/c325754f067a267fd5fc1990a91db90f37993215",
                    "version": "v1.19.0"
```