### PR TITLE
CM-780: [release-1.19] [GA] Promote 1.19.0 latest staging builds to GA

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,22 +4,22 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # cert-manager operator image digest.
-CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
 
 # cert-manager operand - webhook component image digest.
-CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
 
 # cert-manager operand - cainjector component image digest.
-CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
 
 # cert-manager operand - controller component image digest.
-CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
 
 # cert-manager operand - acmesolver component image digest.
-CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
+CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
 
 # cert-manager-istiocsr operand image digest.
-CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
+CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
 
 # cert-manager trust-manager operand image digest.
-CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82


### PR DESCRIPTION
Update 1.19.0 prod build image sha256 references



- [x] Test with image pull

```sh

> podman pull registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
Trying to pull registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:ac464eacb59871d6756af0d871f1fb3313f3659a47634ddb25b4d12e19918e4c
Copying blob sha256:f7c1b31b8294524de5dff6550312e7fc2a074a842daad5dd610d9bfdab56527d
Copying config sha256:e33fabf9c8aa05fad0a9e4ac8c3987ecfe411b66a6cbf9e9874a4c5cf8f9ea4f
Writing manifest to image destination
Storing signatures
e33fabf9c8aa05fad0a9e4ac8c3987ecfe411b66a6cbf9e9874a4c5cf8f9ea4f



> podman pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
Trying to pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:448329ade3b654944299e4b65e1b4c2552bdb1b3166e493b7ed79e57a366923b
Copying blob sha256:f7c1b31b8294524de5dff6550312e7fc2a074a842daad5dd610d9bfdab56527d
Copying config sha256:605da57ca91315aed48a665b9796f141b788d1a659cde3a033ed0062eeddf8ac
Writing manifest to image destination
Storing signatures
605da57ca91315aed48a665b9796f141b788d1a659cde3a033ed0062eeddf8ac


> podman pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
Trying to pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:1608eedf5aa7df058ae5301ddebce01af3ad5e31a16fb4be736d87b6b462b867
Copying blob sha256:f7c1b31b8294524de5dff6550312e7fc2a074a842daad5dd610d9bfdab56527d
Copying config sha256:60489e1db29c049fa84b7ee5ef3e4b0a92a0ce82d9d022fb9022e2a5f73d9465
Writing manifest to image destination
Storing signatures
60489e1db29c049fa84b7ee5ef3e4b0a92a0ce82d9d022fb9022e2a5f73d9465


> podman pull registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
Trying to pull registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:7ae70871e7665d6ff319d270abe545c9e6b6f7b7a9fcd39c3755b6d45aac9eeb
Copying blob sha256:f7c1b31b8294524de5dff6550312e7fc2a074a842daad5dd610d9bfdab56527d
Copying config sha256:ef950550be17f2672e9f197ecd51d036bb4447a7911db01f10ee1928d37032e0
Writing manifest to image destination
Storing signatures
ef950550be17f2672e9f197ecd51d036bb4447a7911db01f10ee1928d37032e0


> podman pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
Trying to pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:05b876a037ac3015bbbbb77b894a9a7248c601f345249ec74add1247430a2e24
Copying blob sha256:f7c1b31b8294524de5dff6550312e7fc2a074a842daad5dd610d9bfdab56527d
Copying config sha256:f59c198a42af6f36269e258664783c78be80d449a76b69fb6aa909f8677163a7
Writing manifest to image destination
Storing signatures
f59c198a42af6f36269e258664783c78be80d449a76b69fb6aa909f8677163a7
```

/cc @bharath-b-rh 