### PR TITLE
CM-780: [GA] Update FBC catalogs for 4.18-4.22 for v1.19.0 GA release

### DIFF
--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-04-15T09:44:09
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-20T13:57:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-04-15T09:44:09
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-20T13:57:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-04-15T09:44:09
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-20T13:57:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-04-15T09:44:09
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-20T13:57:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
 name: cert-manager-operator.v1.19.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-04-15T09:44:09
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-04-20T13:57:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
   name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:df3d7b9db9e04c0ea2f58ccc339ae6f61b80944d1d58e7d78330d1bfed2a83ab
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
   name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
   name: cert-manager-controller
 schema: olm.bundle


### PR DESCRIPTION
## Description

PR is for updating the 4.18-4.22 release catalogs with the GA images of bundle, operator and operand for 1.19.0 release


## Steps used

- [x]  Tested with podman pull

```sh
> podman pull --arch amd64 registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3
Trying to pull registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:28086f4daf68bf89b886ca2aa36f625cc764e922b0ef11a977fd509063076361
Copying blob sha256:b1ed13c5ef0ac6dbcd255a5c1be9e3c9c2903872aa4ae5fa877850a48fdaee26
Copying config sha256:df7311fe93e730dc6d3d65a73c992b1583cc3d49b2e20975439f4718eb9ac4f5
Writing manifest to image destination
Storing signatures
df7311fe93e730dc6d3d65a73c992b1583cc3d49b2e20975439f4718eb9ac4f5

> podman inspect registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/aee89ca028e67a7b59f1c33db686ef3cc9bf69ba",
                    "version": "v1.19.0"
```

```sh
> export REGISTRY_AUTH_FILE=~/.config/containers/auth.json
```

Had to do some manual changes for MAC PC
```diff
diff --git a/hack/update_catalog.sh b/hack/update_catalog.sh
index 7f80d261..a4663c55 100755
--- a/hack/update_catalog.sh
+++ b/hack/update_catalog.sh
@@ -10,6 +10,8 @@
 # yes
 #

+shopt -s extglob
+
 declare OPM_TOOL_PATH
 declare OPERATOR_BUNDLE_IMAGE
 declare CATALOG_DIR
```

- [x] Update FBC calalogs for 4.18+ for v1.19.0 GA release

```sh
 ~/go/src/github.com/chiragkyal/cert-manager-operator-release | on 1.19.0-fbc-ga ?1 ..................................................................................... % | at 20:21:43
> make update-catalog OPERATOR_BUNDLE_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 CATALOG_DIR=catalogs/v4.18/catalog BUNDLE_FILE_NAME=bundle-v1.19.0.yaml REPLICATE_BUNDLE_FILE_IN_CATALOGS=no USE_MIGRATE_LEVEL_FLAG=yes

./hack/update_catalog.sh /Users/ckyal/go/src/github.com/chiragkyal/cert-manager-operator-release/bin/tools/opm registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 catalogs/v4.18/catalog bundle-v1.19.0.yaml no yes
[Mon Apr 20 20:22:47 IST 2026] -- INFO  -- /Users/ckyal/go/src/github.com/chiragkyal/cert-manager-operator-release/bin/tools/opm registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 catalogs/v4.18/catalog bundle-v1.19.0.yaml no yes
[Mon Apr 20 20:22:47 IST 2026] -- INFO  -- inspecting registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 bundle image
[Mon Apr 20 20:22:50 IST 2026] -- INFO  -- generating catalog bundle "catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.0.yaml"

 ~/go/src/github.com/chiragkyal/cert-manager-operator-release | on 1.19.0-fbc-ga !2 ?1 ....................................................................... took 37s | % | at 20:23:24
> make update-catalog OPERATOR_BUNDLE_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 CATALOG_DIR=catalogs/v4.19/catalog BUNDLE_FILE_NAME=bundle-v1.19.0.yaml REPLICATE_BUNDLE_FILE_IN_CATALOGS=no USE_MIGRATE_LEVEL_FLAG=yes


 ~/go/src/github.com/chiragkyal/cert-manager-operator-release | on 1.19.0-fbc-ga !3 ?1 ....................................................................... took 44s | % | at 20:28:17
> make update-catalog OPERATOR_BUNDLE_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 CATALOG_DIR=catalogs/v4.20/catalog BUNDLE_FILE_NAME=bundle-v1.19.0.yaml REPLICATE_BUNDLE_FILE_IN_CATALOGS=no USE_MIGRATE_LEVEL_FLAG=yes


 ~/go/src/github.com/chiragkyal/cert-manager-operator-release | on 1.19.0-fbc-ga !4 ?1 ....................................................................... took 36s | % | at 20:29:01
> make update-catalog OPERATOR_BUNDLE_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 CATALOG_DIR=catalogs/v4.21/catalog BUNDLE_FILE_NAME=bundle-v1.19.0.yaml REPLICATE_BUNDLE_FILE_IN_CATALOGS=no USE_MIGRATE_LEVEL_FLAG=yes


 ~/go/src/github.com/chiragkyal/cert-manager-operator-release | on 1.19.0-fbc-ga !5 ?1 ....................................................................... took 27s | % | at 20:30:21
> make update-catalog OPERATOR_BUNDLE_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:1c06966e5d2ecdb91409068cd8d289b46b3e5a27af1694ce71db1f94379a18c3 CATALOG_DIR=catalogs/v4.22/catalog BUNDLE_FILE_NAME=bundle-v1.19.0.yaml REPLICATE_BUNDLE_FILE_IN_CATALOGS=no USE_MIGRATE_LEVEL_FLAG=yes

```
