### PR TITLE
[release-1.20] CM-987: Prepare release-1.20 Konflux pipelines and Go 1.26 builder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "jetstack-cert-manager"]
 	path = cert-manager
 	url = https://github.com/openshift/jetstack-cert-manager.git
-	branch = release-1.19
+	branch = release-1.20
 [submodule "cert-manager-operator"]
 	path = cert-manager-operator
 	url = https://github.com/openshift/cert-manager-operator.git
-	branch = cert-manager-1.19
+	branch = cert-manager-1.20
 [submodule "cert-manager-istio-csr"]
 	path = cert-manager-istio-csr
 	url = https://github.com/openshift/cert-manager-istio-csr.git
-	branch = release-1.19
+	branch = release-1.20
 [submodule "cert-manager-trust-manager"]
 	path = trust-manager
 	url = https://github.com/openshift/cert-manager-trust-manager.git

--- a/.tekton/cert-manager-istio-csr-1-20-pull-request.yaml
+++ b/.tekton/cert-manager-istio-csr-1-20-pull-request.yaml
@@ -4,18 +4,19 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.19" && (".tekton/jetstack-cert-manager-acmesolver-1-19-push.yaml".pathChanged() ||
-      "Containerfile.cert-manager.acmesolver".pathChanged() || "cert-manager".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-1.20" && (".tekton/cert-manager-istio-csr-1-20-pull-request.yaml".pathChanged() ||
+      "Containerfile.cert-manager-istio-csr".pathChanged() || "cert-manager-istio-csr".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: jetstack-cert-manager-1-19
-    appstudio.openshift.io/component: jetstack-cert-manager-acmesolver-1-19
+    appstudio.openshift.io/application: cert-manager-istio-csr-1-20
+    appstudio.openshift.io/component: cert-manager-istio-csr-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: jetstack-cert-manager-acmesolver-1-19-on-push
+  name: cert-manager-istio-csr-1-20-on-pull-request
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -24,26 +25,28 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/jetstack-cert-manager-1-19/jetstack-cert-manager-acmesolver-1-19:{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-istio-csr-1-20/cert-manager-istio-csr-1-20:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
-    value: Containerfile.cert-manager.acmesolver
+    value: Containerfile.cert-manager-istio-csr
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.19.5
+    - RELEASE_VERSION=v0.16.0-1
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "cert-manager"}'
+    value: '{"type": "gomod", "path": "cert-manager-istio-csr"}'
   - name: snyk-org-id
     value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
   - name: snyk-proj-name
-    value: "jetstack-cert-manager"
+    value: "cert-manager-istio-csr"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-jetstack-cert-manager-acmesolver-1-19
+    serviceAccountName: build-pipeline-cert-manager-istio-csr-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-istio-csr-1-20-push.yaml
+++ b/.tekton/cert-manager-istio-csr-1-20-push.yaml
@@ -8,14 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.19" && (".tekton/jetstack-cert-manager-1-19-push.yaml".pathChanged() ||
-      "Containerfile.cert-manager".pathChanged() || "cert-manager".pathChanged())
+      == "release-1.20" && (".tekton/cert-manager-istio-csr-1-20-push.yaml".pathChanged() ||
+      "Containerfile.cert-manager-istio-csr".pathChanged() || "cert-manager-istio-csr".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: jetstack-cert-manager-1-19
-    appstudio.openshift.io/component: jetstack-cert-manager-1-19
+    appstudio.openshift.io/application: cert-manager-istio-csr-1-20
+    appstudio.openshift.io/component: cert-manager-istio-csr-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: jetstack-cert-manager-1-19-on-push
+  name: cert-manager-istio-csr-1-20-on-push
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -24,26 +24,26 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/jetstack-cert-manager-1-19/jetstack-cert-manager-1-19:{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-istio-csr-1-20/cert-manager-istio-csr-1-20:{{revision}}
   - name: dockerfile
-    value: Containerfile.cert-manager
+    value: Containerfile.cert-manager-istio-csr
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.19.5
+    - RELEASE_VERSION=v0.16.0-1
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "cert-manager"}'
+    value: '{"type": "gomod", "path": "cert-manager-istio-csr"}'
   - name: snyk-org-id
     value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
   - name: snyk-proj-name
-    value: "jetstack-cert-manager"
+    value: "cert-manager-istio-csr"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-jetstack-cert-manager-1-19
+    serviceAccountName: build-pipeline-cert-manager-istio-csr-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-operator-1-20-pull-request.yaml
+++ b/.tekton/cert-manager-operator-1-20-pull-request.yaml
@@ -9,15 +9,15 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.19" && (".tekton/cert-manager-operator-bundle-1-19-pull-request.yaml".pathChanged() ||
-      ".tekton/single-arch-build-pipeline.yaml".pathChanged() || "Containerfile.cert-manager-operator.bundle".pathChanged() ||
-      "hack/bundle/render_templates.sh".pathChanged() || "cert-manager-operator".pathChanged() || "images_digest.conf".pathChanged())
+      == "release-1.20" && (".tekton/cert-manager-operator-1-20-pull-request.yaml".pathChanged() ||
+      ".tekton/multi-arch-build-pipeline.yaml".pathChanged() || "Containerfile.cert-manager-operator".pathChanged() ||
+      "cert-manager-operator".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cert-manager-operator-1-19
-    appstudio.openshift.io/component: cert-manager-operator-bundle-1-19
+    appstudio.openshift.io/application: cert-manager-operator-1-20
+    appstudio.openshift.io/component: cert-manager-operator-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: cert-manager-operator-bundle-1-19-on-pull-request
+  name: cert-manager-operator-1-20-on-pull-request
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -26,28 +26,26 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator-1-19/cert-manager-operator-bundle-1-19:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator-1-20/cert-manager-operator-1-20:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Containerfile.cert-manager-operator.bundle
+    value: Containerfile.cert-manager-operator
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.19.1
+    - RELEASE_VERSION=v1.20.0
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
   - name: snyk-org-id
     value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
   - name: snyk-proj-name
     value: "cert-manager-operator"
   pipelineRef:
-    name: single-arch-build-pipeline
+    name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cert-manager-operator-bundle-1-19
+    serviceAccountName: build-pipeline-cert-manager-operator-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-operator-1-20-push.yaml
+++ b/.tekton/cert-manager-operator-1-20-push.yaml
@@ -4,20 +4,19 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.19" && (".tekton/cert-manager-operator-1-19-pull-request.yaml".pathChanged() ||
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-1.20" && (".tekton/cert-manager-operator-1-20-push.yaml".pathChanged() ||
       ".tekton/multi-arch-build-pipeline.yaml".pathChanged() || "Containerfile.cert-manager-operator".pathChanged() ||
       "cert-manager-operator".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cert-manager-operator-1-19
-    appstudio.openshift.io/component: cert-manager-operator-1-19
+    appstudio.openshift.io/application: cert-manager-operator-1-20
+    appstudio.openshift.io/component: cert-manager-operator-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: cert-manager-operator-1-19-on-pull-request
+  name: cert-manager-operator-1-20-on-push
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -26,16 +25,14 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator-1-19/cert-manager-operator-1-19:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator-1-20/cert-manager-operator-1-20:{{revision}}
   - name: dockerfile
     value: Containerfile.cert-manager-operator
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.19.1
+    - RELEASE_VERSION=v1.20.0
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: snyk-org-id
@@ -45,7 +42,7 @@ spec:
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cert-manager-operator-1-19
+    serviceAccountName: build-pipeline-cert-manager-operator-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-operator-bundle-1-20-pull-request.yaml
+++ b/.tekton/cert-manager-operator-bundle-1-20-pull-request.yaml
@@ -4,19 +4,20 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.19" && (".tekton/cert-manager-operator-bundle-1-19-push.yaml".pathChanged() ||
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-1.20" && (".tekton/cert-manager-operator-bundle-1-20-pull-request.yaml".pathChanged() ||
       ".tekton/single-arch-build-pipeline.yaml".pathChanged() || "Containerfile.cert-manager-operator.bundle".pathChanged() ||
       "hack/bundle/render_templates.sh".pathChanged() || "cert-manager-operator".pathChanged() || "images_digest.conf".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cert-manager-operator-1-19
-    appstudio.openshift.io/component: cert-manager-operator-bundle-1-19
+    appstudio.openshift.io/application: cert-manager-operator-1-20
+    appstudio.openshift.io/component: cert-manager-operator-bundle-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: cert-manager-operator-bundle-1-19-on-push
+  name: cert-manager-operator-bundle-1-20-on-pull-request
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -25,14 +26,16 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator-1-19/cert-manager-operator-bundle-1-19:{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator-1-20/cert-manager-operator-bundle-1-20:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
     value: Containerfile.cert-manager-operator.bundle
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.19.1
+    - RELEASE_VERSION=v1.20.0
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input
@@ -44,7 +47,7 @@ spec:
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cert-manager-operator-bundle-1-19
+    serviceAccountName: build-pipeline-cert-manager-operator-bundle-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-operator-bundle-1-20-push.yaml
+++ b/.tekton/cert-manager-operator-bundle-1-20-push.yaml
@@ -8,14 +8,15 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.19" && (".tekton/cert-manager-istio-csr-1-19-push.yaml".pathChanged() ||
-      "Containerfile.cert-manager-istio-csr".pathChanged() || "cert-manager-istio-csr".pathChanged())
+      == "release-1.20" && (".tekton/cert-manager-operator-bundle-1-20-push.yaml".pathChanged() ||
+      ".tekton/single-arch-build-pipeline.yaml".pathChanged() || "Containerfile.cert-manager-operator.bundle".pathChanged() ||
+      "hack/bundle/render_templates.sh".pathChanged() || "cert-manager-operator".pathChanged() || "images_digest.conf".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cert-manager-istio-csr-1-19
-    appstudio.openshift.io/component: cert-manager-istio-csr-1-19
+    appstudio.openshift.io/application: cert-manager-operator-1-20
+    appstudio.openshift.io/component: cert-manager-operator-bundle-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: cert-manager-istio-csr-1-19-on-push
+  name: cert-manager-operator-bundle-1-20-on-push
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -24,26 +25,26 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-istio-csr-1-19/cert-manager-istio-csr-1-19:{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator-1-20/cert-manager-operator-bundle-1-20:{{revision}}
   - name: dockerfile
-    value: Containerfile.cert-manager-istio-csr
+    value: Containerfile.cert-manager-operator.bundle
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v0.16.0-1
+    - RELEASE_VERSION=v1.20.0
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "cert-manager-istio-csr"}'
+    value: '{"type": "gomod", "path": "."}'
   - name: snyk-org-id
     value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
   - name: snyk-proj-name
-    value: "cert-manager-istio-csr"
+    value: "cert-manager-operator"
   pipelineRef:
-    name: multi-arch-build-pipeline
+    name: single-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cert-manager-istio-csr-1-19
+    serviceAccountName: build-pipeline-cert-manager-operator-bundle-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-trust-manager-1-20-pull-request.yaml
+++ b/.tekton/cert-manager-trust-manager-1-20-pull-request.yaml
@@ -9,14 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.19" && (".tekton/cert-manager-istio-csr-1-19-pull-request.yaml".pathChanged() ||
-      "Containerfile.cert-manager-istio-csr".pathChanged() || "cert-manager-istio-csr".pathChanged())
+      == "release-1.20" && (".tekton/cert-manager-trust-manager-1-20-pull-request.yaml".pathChanged() ||
+      "Containerfile.cert-manager-trust-manager".pathChanged() || "trust-manager".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cert-manager-istio-csr-1-19
-    appstudio.openshift.io/component: cert-manager-istio-csr-1-19
+    appstudio.openshift.io/application: cert-manager-trust-manager-1-20
+    appstudio.openshift.io/component: cert-manager-trust-manager-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: cert-manager-istio-csr-1-19-on-pull-request
+  name: cert-manager-trust-manager-1-20-on-pull-request
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -25,28 +25,28 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-istio-csr-1-19/cert-manager-istio-csr-1-19:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-trust-manager-1-20/cert-manager-trust-manager-1-20:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Containerfile.cert-manager-istio-csr
+    value: Containerfile.cert-manager-trust-manager
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v0.16.0-1
+    - RELEASE_VERSION=v0.20.3
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "cert-manager-istio-csr"}'
+    value: '{"type": "gomod", "path": "trust-manager"}'
   - name: snyk-org-id
     value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
   - name: snyk-proj-name
-    value: "cert-manager-istio-csr"
+    value: "cert-manager-trust-manager"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cert-manager-istio-csr-1-19
+    serviceAccountName: build-pipeline-cert-manager-trust-manager-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cert-manager-trust-manager-1-20-push.yaml
+++ b/.tekton/cert-manager-trust-manager-1-20-push.yaml
@@ -4,19 +4,18 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cert-manager-operator-release?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.19" && (".tekton/cert-manager-trust-manager-1-19-pull-request.yaml".pathChanged() ||
+      == "release-1.20" && (".tekton/cert-manager-trust-manager-1-20-push.yaml".pathChanged() ||
       "Containerfile.cert-manager-trust-manager".pathChanged() || "trust-manager".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cert-manager-trust-manager-1-19
-    appstudio.openshift.io/component: cert-manager-trust-manager-1-19
+    appstudio.openshift.io/application: cert-manager-trust-manager-1-20
+    appstudio.openshift.io/component: cert-manager-trust-manager-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: cert-manager-trust-manager-1-19-on-pull-request
+  name: cert-manager-trust-manager-1-20-on-push
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -25,9 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-trust-manager-1-19/cert-manager-trust-manager-1-19:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-trust-manager-1-20/cert-manager-trust-manager-1-20:{{revision}}
   - name: dockerfile
     value: Containerfile.cert-manager-trust-manager
   - name: path-context
@@ -46,7 +43,7 @@ spec:
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cert-manager-trust-manager-1-19
+    serviceAccountName: build-pipeline-cert-manager-trust-manager-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/jetstack-cert-manager-1-20-pull-request.yaml
+++ b/.tekton/jetstack-cert-manager-1-20-pull-request.yaml
@@ -9,14 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.19" && (".tekton/jetstack-cert-manager-acmesolver-1-19-pull-request.yaml".pathChanged() ||
-      "Containerfile.cert-manager.acmesolver".pathChanged() || "cert-manager".pathChanged())
+      == "release-1.20" && (".tekton/jetstack-cert-manager-1-20-pull-request.yaml".pathChanged() ||
+      "Containerfile.cert-manager".pathChanged() || "cert-manager".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: jetstack-cert-manager-1-19
-    appstudio.openshift.io/component: jetstack-cert-manager-acmesolver-1-19
+    appstudio.openshift.io/application: jetstack-cert-manager-1-20
+    appstudio.openshift.io/component: jetstack-cert-manager-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: jetstack-cert-manager-acmesolver-1-19-on-pull-request
+  name: jetstack-cert-manager-1-20-on-pull-request
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -25,16 +25,16 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/jetstack-cert-manager-1-19/jetstack-cert-manager-acmesolver-1-19:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/jetstack-cert-manager-1-20/jetstack-cert-manager-1-20:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Containerfile.cert-manager.acmesolver
+    value: Containerfile.cert-manager
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.19.5
+    - RELEASE_VERSION=v1.20.2
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input
@@ -46,7 +46,7 @@ spec:
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-jetstack-cert-manager-acmesolver-1-19
+    serviceAccountName: build-pipeline-jetstack-cert-manager-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/jetstack-cert-manager-1-20-push.yaml
+++ b/.tekton/jetstack-cert-manager-1-20-push.yaml
@@ -7,15 +7,15 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.19" && (".tekton/cert-manager-trust-manager-1-19-push.yaml".pathChanged() ||
-      "Containerfile.cert-manager-trust-manager".pathChanged() || "trust-manager".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-1.20" && (".tekton/jetstack-cert-manager-1-20-push.yaml".pathChanged() ||
+      "Containerfile.cert-manager".pathChanged() || "cert-manager".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cert-manager-trust-manager-1-19
-    appstudio.openshift.io/component: cert-manager-trust-manager-1-19
+    appstudio.openshift.io/application: jetstack-cert-manager-1-20
+    appstudio.openshift.io/component: jetstack-cert-manager-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: cert-manager-trust-manager-1-19-on-push
+  name: jetstack-cert-manager-1-20-on-push
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -24,26 +24,26 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-trust-manager-1-19/cert-manager-trust-manager-1-19:{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/jetstack-cert-manager-1-20/jetstack-cert-manager-1-20:{{revision}}
   - name: dockerfile
-    value: Containerfile.cert-manager-trust-manager
+    value: Containerfile.cert-manager
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v0.20.3
+    - RELEASE_VERSION=v1.20.2
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "trust-manager"}'
+    value: '{"type": "gomod", "path": "cert-manager"}'
   - name: snyk-org-id
     value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
   - name: snyk-proj-name
-    value: "cert-manager-trust-manager"
+    value: "jetstack-cert-manager"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cert-manager-trust-manager-1-19
+    serviceAccountName: build-pipeline-jetstack-cert-manager-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/jetstack-cert-manager-acmesolver-1-20-pull-request.yaml
+++ b/.tekton/jetstack-cert-manager-acmesolver-1-20-pull-request.yaml
@@ -9,14 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.19" && (".tekton/jetstack-cert-manager-1-19-pull-request.yaml".pathChanged() ||
-      "Containerfile.cert-manager".pathChanged() || "cert-manager".pathChanged())
+      == "release-1.20" && (".tekton/jetstack-cert-manager-acmesolver-1-20-pull-request.yaml".pathChanged() ||
+      "Containerfile.cert-manager.acmesolver".pathChanged() || "cert-manager".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: jetstack-cert-manager-1-19
-    appstudio.openshift.io/component: jetstack-cert-manager-1-19
+    appstudio.openshift.io/application: jetstack-cert-manager-1-20
+    appstudio.openshift.io/component: jetstack-cert-manager-acmesolver-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: jetstack-cert-manager-1-19-on-pull-request
+  name: jetstack-cert-manager-acmesolver-1-20-on-pull-request
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -25,16 +25,16 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/jetstack-cert-manager-1-19/jetstack-cert-manager-1-19:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/jetstack-cert-manager-1-20/jetstack-cert-manager-acmesolver-1-20:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Containerfile.cert-manager
+    value: Containerfile.cert-manager.acmesolver
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.19.5
+    - RELEASE_VERSION=v1.20.2
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input
@@ -46,7 +46,7 @@ spec:
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-jetstack-cert-manager-1-19
+    serviceAccountName: build-pipeline-jetstack-cert-manager-acmesolver-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/jetstack-cert-manager-acmesolver-1-20-push.yaml
+++ b/.tekton/jetstack-cert-manager-acmesolver-1-20-push.yaml
@@ -8,15 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.19" && (".tekton/cert-manager-operator-1-19-push.yaml".pathChanged() ||
-      ".tekton/multi-arch-build-pipeline.yaml".pathChanged() || "Containerfile.cert-manager-operator".pathChanged() ||
-      "cert-manager-operator".pathChanged())
+      == "release-1.20" && (".tekton/jetstack-cert-manager-acmesolver-1-20-push.yaml".pathChanged() ||
+      "Containerfile.cert-manager.acmesolver".pathChanged() || "cert-manager".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cert-manager-operator-1-19
-    appstudio.openshift.io/component: cert-manager-operator-1-19
+    appstudio.openshift.io/application: jetstack-cert-manager-1-20
+    appstudio.openshift.io/component: jetstack-cert-manager-acmesolver-1-20
     pipelines.appstudio.openshift.io/type: build
-  name: cert-manager-operator-1-19-on-push
+  name: jetstack-cert-manager-acmesolver-1-20-on-push
   namespace: cert-manager-oape-tenant
 spec:
   params:
@@ -25,24 +24,26 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/cert-manager-operator-1-19/cert-manager-operator-1-19:{{revision}}
+    value: quay.io/redhat-user-workloads/cert-manager-oape-tenant/jetstack-cert-manager-1-20/jetstack-cert-manager-acmesolver-1-20:{{revision}}
   - name: dockerfile
-    value: Containerfile.cert-manager-operator
+    value: Containerfile.cert-manager.acmesolver
   - name: path-context
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.19.1
+    - RELEASE_VERSION=v1.20.2
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "cert-manager"}'
   - name: snyk-org-id
     value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
   - name: snyk-proj-name
-    value: "cert-manager-operator"
+    value: "jetstack-cert-manager"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cert-manager-operator-1-19
+    serviceAccountName: build-pipeline-jetstack-cert-manager-acmesolver-1-20
   workspaces:
   - name: git-auth
     secret:

--- a/Containerfile.cert-manager
+++ b/Containerfile.cert-manager
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
 ARG SOURCE_DIR="/go/src/github.com/openshift/jetstack-cert-manager"
 
 COPY cert-manager $SOURCE_DIR

--- a/Containerfile.cert-manager-istio-csr
+++ b/Containerfile.cert-manager-istio-csr
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
 
 ARG SOURCE_DIR="/go/src/github.com/openshift/cert-manager-istio-csr"
 

--- a/Containerfile.cert-manager-operator
+++ b/Containerfile.cert-manager-operator
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
 
 ARG SOURCE_DIR="/go/src/github.com/openshift/cert-manager-operator"
 ARG COMMIT_SHA

--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
 
 COPY cert-manager-operator/bundle/manifests /manifests
 COPY cert-manager-operator/bundle/metadata /metadata

--- a/Containerfile.cert-manager-trust-manager
+++ b/Containerfile.cert-manager-trust-manager
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
 
 ARG SOURCE_DIR="/go/src/github.com/openshift/cert-manager-trust-manager"
 

--- a/Containerfile.cert-manager.acmesolver
+++ b/Containerfile.cert-manager.acmesolver
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
 
 ARG SOURCE_DIR="/go/src/github.com/openshift/jetstack-cert-manager"
 


### PR DESCRIPTION
## Summary
- Rename all `.tekton` pipeline files from `1-19` to `1-20` and update Konflux labels, triggers, and image paths for `release-1.20`
- Set operand `RELEASE_VERSION` values: operator/bundle `v1.20.0`, jetstack/acmesolver `v1.20.2`, trust-manager `v0.20.3`, istio-csr `v0.16.0-1`
- Bump all operand Containerfiles to `openshift-golang-builder:rhel_9_golang_1.26`

## Test plan
- [ ] `make verify-containerfiles`
- [ ] Konflux PR pipelines trigger on `release-1.20`
- [ ] Operand image builds succeed in Konflux