### PR TITLE
NO-JIRA: Updates doc on disabling konflux pipeline for EOL releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ Use the command below to get usage summary and interact with the repository.
 ```console
 make help
 ```
+
+## Automated dependency updates
+
+MintMaker (`red-hat-konflux[bot]`) opens pull requests to refresh dependencies in this repository, including Tekton pipeline references under `.tekton/`. Konflux Components for the end-of-life releases below are annotated so they no longer receive those updates:
+
+| cert-manager version | Repository branch |
+|----------------------|-------------------|
+| 1.14.x               | `release-1.14`    |
+| 1.15.x               | `release-1.15`    |
+| 1.16.x               | `release-1.16`    |
+
+See [docs/development/konflux.md](docs/development/konflux.md#disabling-mintmaker-for-end-of-life-releases) for how to disable or manage these updates when a release reaches end of life.

--- a/docs/development/konflux.md
+++ b/docs/development/konflux.md
@@ -34,3 +34,41 @@ Refer below PRs for more details on the above changes.
 - https://github.com/openshift/cert-manager-operator-release/pull/5
 - https://github.com/openshift/cert-manager-operator-release/pull/6
 - https://github.com/openshift/cert-manager-operator-release/pull/7
+
+## Disabling MintMaker for end-of-life releases
+
+MintMaker is the Konflux dependency update service built on [Renovate](https://docs.renovatebot.com/). On GitHub it appears as `red-hat-konflux[bot]` and commonly opens pull requests titled **chore(deps): update konflux references** to refresh Tekton task bundle digests and related image references in `.tekton/`. Repository-level behavior is configured in `renovate.json` at the root of the default branch.
+
+Each supported release is represented by one or more Konflux **Components** in App Studio (one Component per Git branch and onboarded image or pipeline). While a release is supported, those Components continue to receive MintMaker updates.
+
+When an OpenShift release reaches end of life, automated updates for that stream are turned off by annotating **every** Konflux Component that targets the EOL Git branch. The supported releases and their annotation status are listed in the [README](../../README.md#automated-dependency-updates).
+
+### Disable updates for a release
+
+1. Identify all Components in your App Studio tenant namespace that use the EOL branch (for example `release-1.14`). Component names match Konflux onboarding (for example `cert-manager-operator-1-14`, `jetstack-cert-manager-1-14`, bundle, catalog/index, and any other Components for that branch).
+
+2. Annotate each Component:
+
+```console
+oc -n <tenant-namespace> annotate component/<component-name> mintmaker.appstudio.redhat.com/disabled=true --overwrite
+```
+
+3. Add the OpenShift version and repository branch to the table in [README.md](../../README.md#automated-dependency-updates).
+
+4. Close any open `red-hat-konflux[bot]` pull requests that target the EOL branch so stale branches are not updated on a later MintMaker run.
+
+Annotating a Component disables **all** MintMaker activity for that repository and branch (Tekton references, Containerfiles, and other managers). Konflux builds are unaffected; only automated dependency bump pull requests stop.
+
+### Re-enable updates
+
+Remove the annotation if a branch should receive MintMaker updates again:
+
+```console
+oc -n <tenant-namespace> annotate component/<component-name> mintmaker.appstudio.redhat.com/disabled- --overwrite
+```
+
+Remove the corresponding row from the README table.
+
+### References
+
+- [Konflux dependency management — offboarding a repository](https://konflux-ci.dev/docs/mintmaker/user/#offboarding-a-repository)


### PR DESCRIPTION
The PR is for updating the READMEs on how to disable mintmaker updates to konflux pipeline configs for EOL releases.