### PR TITLE
CM-987: Fix container image labels for release 1.20

### DIFF
--- a/Containerfile.cert-manager
+++ b/Containerfile.cert-manager
@@ -32,7 +32,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="jetstack-cert-manager-container" \
-      cpe="cpe:/a:redhat:cert_manager:1.19::el9" \
+      cpe="cpe:/a:redhat:cert_manager:1.20::el9" \
       name="cert-manager/jetstack-cert-manager-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager" \

--- a/Containerfile.cert-manager-istio-csr
+++ b/Containerfile.cert-manager-istio-csr
@@ -29,7 +29,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="cert-manager-istio-csr-container" \
-      cpe="cpe:/a:redhat:cert_manager:1.19::el9" \
+      cpe="cpe:/a:redhat:cert_manager:1.20::el9" \
       name="cert-manager/cert-manager-istio-csr-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager-istio-csr" \

--- a/Containerfile.cert-manager-operator
+++ b/Containerfile.cert-manager-operator
@@ -32,7 +32,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="cert-manager-operator-container" \
-      cpe="cpe:/a:redhat:cert_manager:1.19::el9" \
+      cpe="cpe:/a:redhat:cert_manager:1.20::el9" \
       name="cert-manager/cert-manager-operator-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager-operator" \

--- a/Containerfile.cert-manager-operator.bundle
+++ b/Containerfile.cert-manager-operator.bundle
@@ -24,7 +24,7 @@ ARG SOURCE_URL
 
 # Core bundle labels.
 LABEL com.redhat.component="cert-manager-operator-bundle-container" \
-      cpe="cpe:/a:redhat:cert_manager:1.19::el9" \
+      cpe="cpe:/a:redhat:cert_manager:1.20::el9" \
       name="cert-manager/cert-manager-operator-bundle" \
       summary="Cert Manager support for OpenShift" \
       description="Cert Manager support for OpenShift" \
@@ -35,7 +35,7 @@ LABEL com.redhat.component="cert-manager-operator-bundle-container" \
       maintainer="Red Hat, Inc." \
       vendor="Red Hat, Inc." \
       com.redhat.delivery.operator.bundle=true \
-      com.redhat.openshift.versions="v4.18-v4.22" \
+      com.redhat.openshift.versions="v4.19-v4.22" \
       io.openshift.expose-services="" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \
@@ -49,7 +49,7 @@ LABEL com.redhat.component="cert-manager-operator-bundle-container" \
       operators.operatorframework.io.bundle.metadata.v1=metadata/ \
       operators.operatorframework.io.bundle.package.v1="openshift-cert-manager-operator" \
       operators.operatorframework.io.bundle.channel.default.v1="stable-v1" \
-      operators.operatorframework.io.bundle.channels.v1="stable-v1,stable-v1.19" \
+      operators.operatorframework.io.bundle.channels.v1="stable-v1,stable-v1.20" \
       operators.operatorframework.io.metrics.builder="operator-sdk-v1.25.1" \
       operators.operatorframework.io.metrics.mediatype.v1="metrics+v1" \
       operators.operatorframework.io.metrics.project_layout="go.kubebuilder.io/v3"

--- a/Containerfile.cert-manager-trust-manager
+++ b/Containerfile.cert-manager-trust-manager
@@ -29,7 +29,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="cert-manager-trust-manager-container" \
-      cpe="cpe:/a:redhat:cert_manager:1.19::el9" \
+      cpe="cpe:/a:redhat:cert_manager:1.20::el9" \
       name="cert-manager/cert-manager-trust-manager-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager-trust-manager" \

--- a/Containerfile.cert-manager.acmesolver
+++ b/Containerfile.cert-manager.acmesolver
@@ -29,7 +29,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="jetstack-cert-manager-acmesolver-container" \
-      cpe="cpe:/a:redhat:cert_manager:1.19::el9" \
+      cpe="cpe:/a:redhat:cert_manager:1.20::el9" \
       name="cert-manager/jetstack-cert-manager-acmesolver-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager-acmesolver" \


### PR DESCRIPTION
## Summary
- Update CPE labels from `1.19` to `1.20` across all containerfiles
- Update bundle OpenShift version label to `v4.19-v4.22`
- Update bundle channel label to `stable-v1,stable-v1.20`

These label updates were missed in the initial release-1.20 Konflux prep PR (#822).

## Test plan
- [ ] Verify Konflux pipeline builds succeed for all container images
- [ ] Confirm bundle image labels are correct in the built operator bundle


Made with [Cursor](https://cursor.com)