### PR TITLE
CM-987: Update image digests for release 1.20 bundle

### DIFF
--- a/.tekton/cert-manager-istio-csr-1-20-pull-request.yaml
+++ b/.tekton/cert-manager-istio-csr-1-20-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v0.16.0-1
+    - RELEASE_VERSION=v0.16.0-2
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/cert-manager-istio-csr-1-20-push.yaml
+++ b/.tekton/cert-manager-istio-csr-1-20-push.yaml
@@ -31,7 +31,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v0.16.0-1
+    - RELEASE_VERSION=v0.16.0-2
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/images_digest.conf
+++ b/images_digest.conf
@@ -19,7 +19,7 @@ CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cer
 CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4c12e931f7267c1b13fd9221bc7e79c6f0bdf44a9c9cdec65559a49a68e2ab4b
 
 # cert-manager-istiocsr operand image digest.
-CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7
+CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a5a6d01acf9b908475bd15c45121305f6f42b74bc0e4ba13bdfc134662b2d095
 
 # cert-manager trust-manager operand image digest.
 CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82

--- a/images_digest.conf
+++ b/images_digest.conf
@@ -19,7 +19,7 @@ CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cer
 CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4c12e931f7267c1b13fd9221bc7e79c6f0bdf44a9c9cdec65559a49a68e2ab4b
 
 # cert-manager-istiocsr operand image digest.
-CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a5a6d01acf9b908475bd15c45121305f6f42b74bc0e4ba13bdfc134662b2d095
+CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7
 
 # cert-manager trust-manager operand image digest.
 CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82

--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,22 +4,22 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # cert-manager operator image digest.
-CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
 
 # cert-manager operand - webhook component image digest.
-CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
 
 # cert-manager operand - cainjector component image digest.
-CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
 
 # cert-manager operand - controller component image digest.
-CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
 
 # cert-manager operand - acmesolver component image digest.
-CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
+CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4c12e931f7267c1b13fd9221bc7e79c6f0bdf44a9c9cdec65559a49a68e2ab4b
 
 # cert-manager-istiocsr operand image digest.
-CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
+CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7
 
 # cert-manager trust-manager operand image digest.
 CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82


### PR DESCRIPTION
## Summary
- Update operator and operand image digests in `images_digest.conf` for the release 1.20 bundle build
- Point operator, cert-manager, acmesolver, and istio-csr images to `registry.stage.redhat.io` stage digests
- Keep trust-manager on `registry.redhat.io` with the current prod digest

## Test plan
- [ ] Verify bundle build renders CSV with updated image references
- [ ] Confirm Konflux bundle pipeline succeeds with the new digests