### PR TITLE
CM-994: Add v1.20.0 stage bundle to FBC catalogs for 4.19-4.22

### DIFF
--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+name: cert-manager-operator.v1.20.0
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.20.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-06-23T11:54:54
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.20.0'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.20.2](https://github.com/cert-manager/cert-manager/tree/v1.20.2), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
+  name: cert-manager-acmesolver
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-webhook
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-ca-injector
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-controller
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:39404aefc48202660c9b4dfae18672cc4ed66d0a9b08fcf5ae70a4504c4e7dff
 name: cert-manager-operator.v1.20.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-06-23T11:54:54
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+      createdAt: 2026-06-23T13:57:11
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
-  name: cert-manager-istiocsr
-- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
-  name: cert-manager-acmesolver
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-webhook
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-ca-injector
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-controller
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:39404aefc48202660c9b4dfae18672cc4ed66d0a9b08fcf5ae70a4504c4e7dff
   name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4c12e931f7267c1b13fd9221bc7e79c6f0bdf44a9c9cdec65559a49a68e2ab4b
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
@@ -26,6 +26,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.20.0
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -147,5 +150,39 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 name: stable-v1.19
+package: openshift-cert-manager-operator
+schema: olm.channel
+---
+entries:
+- name: cert-manager-operator.v1.15.0
+  replaces: cert-manager-operator.v1.14.1
+  skipRange: '>=1.14.1 <1.15.0'
+- name: cert-manager-operator.v1.15.1
+  replaces: cert-manager-operator.v1.15.0
+  skipRange: '>=1.15.0 <1.15.1'
+- name: cert-manager-operator.v1.16.0
+  replaces: cert-manager-operator.v1.15.1
+  skipRange: '>=1.15.1 <1.16.0'
+- name: cert-manager-operator.v1.16.1
+  replaces: cert-manager-operator.v1.15.1
+  skipRange: '>=1.15.1 <1.16.1'
+  skips:
+    - cert-manager-operator.v1.16.0
+- name: cert-manager-operator.v1.17.0
+  replaces: cert-manager-operator.v1.16.1
+  skipRange: '>=1.16.1 <1.17.0'
+- name: cert-manager-operator.v1.18.0
+  replaces: cert-manager-operator.v1.17.0
+  skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
+- name: cert-manager-operator.v1.19.0
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.20.0
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+name: stable-v1.20
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+name: cert-manager-operator.v1.20.0
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.20.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-06-23T11:54:54
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.20.0'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.20.2](https://github.com/cert-manager/cert-manager/tree/v1.20.2), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
+  name: cert-manager-acmesolver
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-webhook
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-ca-injector
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-controller
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:39404aefc48202660c9b4dfae18672cc4ed66d0a9b08fcf5ae70a4504c4e7dff
 name: cert-manager-operator.v1.20.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-06-23T11:54:54
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+      createdAt: 2026-06-23T13:57:11
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
-  name: cert-manager-istiocsr
-- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
-  name: cert-manager-acmesolver
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-webhook
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-ca-injector
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-controller
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:39404aefc48202660c9b4dfae18672cc4ed66d0a9b08fcf5ae70a4504c4e7dff
   name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4c12e931f7267c1b13fd9221bc7e79c6f0bdf44a9c9cdec65559a49a68e2ab4b
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/channel.yaml
@@ -12,6 +12,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.20.0
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -55,5 +58,25 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 name: stable-v1.19
+package: openshift-cert-manager-operator
+schema: olm.channel
+---
+entries:
+- name: cert-manager-operator.v1.17.0
+  replaces: cert-manager-operator.v1.16.1
+  skipRange: '>=1.16.1 <1.17.0'
+- name: cert-manager-operator.v1.18.0
+  replaces: cert-manager-operator.v1.17.0
+  skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
+- name: cert-manager-operator.v1.19.0
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.20.0
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+name: stable-v1.20
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+name: cert-manager-operator.v1.20.0
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.20.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-06-23T11:54:54
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.20.0'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.20.2](https://github.com/cert-manager/cert-manager/tree/v1.20.2), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
+  name: cert-manager-acmesolver
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-webhook
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-ca-injector
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-controller
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:39404aefc48202660c9b4dfae18672cc4ed66d0a9b08fcf5ae70a4504c4e7dff
 name: cert-manager-operator.v1.20.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-06-23T11:54:54
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+      createdAt: 2026-06-23T13:57:11
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
-  name: cert-manager-istiocsr
-- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
-  name: cert-manager-acmesolver
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-webhook
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-ca-injector
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-controller
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:39404aefc48202660c9b4dfae18672cc4ed66d0a9b08fcf5ae70a4504c4e7dff
   name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4c12e931f7267c1b13fd9221bc7e79c6f0bdf44a9c9cdec65559a49a68e2ab4b
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/channel.yaml
@@ -9,6 +9,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.20.0
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -35,5 +38,22 @@ entries:
     replaces: cert-manager-operator.v1.18.1
     skipRange: '>=1.18.1 <1.19.0'
 name: stable-v1.19
+package: openshift-cert-manager-operator
+schema: olm.channel
+---
+entries:
+  - name: cert-manager-operator.v1.18.0
+    replaces: cert-manager-operator.v1.17.0
+    skipRange: '>=1.17.0 <1.18.0'
+  - name: cert-manager-operator.v1.18.1
+    replaces: cert-manager-operator.v1.18.0
+    skipRange: '>=1.18.0 <1.18.1'
+  - name: cert-manager-operator.v1.19.0
+    replaces: cert-manager-operator.v1.18.1
+    skipRange: '>=1.18.1 <1.19.0'
+  - name: cert-manager-operator.v1.20.0
+    replaces: cert-manager-operator.v1.19.0
+    skipRange: '>=1.19.0 <1.20.0'
+name: stable-v1.20
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+name: cert-manager-operator.v1.20.0
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.20.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+      createdAt: 2026-06-23T11:54:54
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.20.0'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.20.2](https://github.com/cert-manager/cert-manager/tree/v1.20.2), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
+  name: cert-manager-acmesolver
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-webhook
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-ca-injector
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+  name: cert-manager-controller
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.20.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:39404aefc48202660c9b4dfae18672cc4ed66d0a9b08fcf5ae70a4504c4e7dff
 name: cert-manager-operator.v1.20.0
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-      createdAt: 2026-06-23T11:54:54
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+      createdAt: 2026-06-23T13:57:11
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
-  name: cert-manager-istiocsr
-- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
-  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
-  name: cert-manager-acmesolver
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-webhook
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-ca-injector
-- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
-  name: cert-manager-controller
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:39404aefc48202660c9b4dfae18672cc4ed66d0a9b08fcf5ae70a4504c4e7dff
   name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4c12e931f7267c1b13fd9221bc7e79c6f0bdf44a9c9cdec65559a49a68e2ab4b
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+  name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/channel.yaml
@@ -3,6 +3,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.20.0
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -12,5 +15,16 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 name: stable-v1.19
+package: openshift-cert-manager-operator
+schema: olm.channel
+---
+entries:
+- name: cert-manager-operator.v1.19.0
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.20.0
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+name: stable-v1.20
 package: openshift-cert-manager-operator
 schema: olm.channel


### PR DESCRIPTION
## Summary
- Add `bundle-v1.20.0.yaml` to FBC catalogs for OpenShift 4.19 through 4.22
- Update `channel.yaml` with v1.20.0 entries in `stable-v1` and new `stable-v1.20` channel
- Bundle rendered from stage image `registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:767ed736c76837a5e930161b14493ee175f964c854a2c4b09e80bb6332b6c508`

## Test plan
- [x] `opm validate` passes for catalogs v4.19, v4.20, v4.21, and v4.22
- [ ] Verify FBC index build pipelines succeed for 4.19-4.22