### PR TITLE
[release-1.20] CM-987: Bump acmesolver RELEASE_VERSION to v1.20.3

### DIFF
--- a/.tekton/jetstack-cert-manager-acmesolver-1-20-pull-request.yaml
+++ b/.tekton/jetstack-cert-manager-acmesolver-1-20-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.20.2
+    - RELEASE_VERSION=v1.20.3
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/jetstack-cert-manager-acmesolver-1-20-push.yaml
+++ b/.tekton/jetstack-cert-manager-acmesolver-1-20-push.yaml
@@ -31,7 +31,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - RELEASE_VERSION=v1.20.2
+    - RELEASE_VERSION=v1.20.3
     - COMMIT_SHA={{revision}}
     - SOURCE_URL={{source_url}}
   - name: prefetch-input


### PR DESCRIPTION
## Summary
- Update `RELEASE_VERSION` for jetstack-cert-manager-acmesolver 1-20 Konflux pipelines from `v1.20.2` to `v1.20.3`
- Affects push and pull-request pipeline configs only; operator/bundle remain `v1.20.0`, main cert-manager operand remains `v1.20.2`

## Test plan
- [ ] Konflux acmesolver PR pipeline triggers on `release-1.20`
- [ ] Operand acmesolver image build succeeds in Konflux
