### PR TITLE
CM-988: Updates bundle with 1.20.0 images digest

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,22 +4,22 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # cert-manager operator image digest.
-CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d8a14cf03a7872a88dd61e1aa6b2a84ce031a2044d0d4d129154041a1adaa481
+CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d8a14cf03a7872a88dd61e1aa6b2a84ce031a2044d0d4d129154041a1adaa481
 
 # cert-manager operand - webhook component image digest.
-CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
+CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
 
 # cert-manager operand - cainjector component image digest.
-CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
+CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
 
 # cert-manager operand - controller component image digest.
-CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
+CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
 
 # cert-manager operand - acmesolver component image digest.
-CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9321868c6d82f1b447e27bb1066eeaa2fa0c3347087d03dced7a775bfddad32e
+CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9321868c6d82f1b447e27bb1066eeaa2fa0c3347087d03dced7a775bfddad32e
 
 # cert-manager-istiocsr operand image digest.
-CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7
+CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:a5fb3245a48f2835b52152827bef540cb2376ace53f2de61756c72d71f536d83
 
 # cert-manager trust-manager operand image digest.
 CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82

--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,19 +4,19 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # cert-manager operator image digest.
-CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:55b00b54a3bc941fde197e2fdbcbf083840ec4376b4e814f8c5f89a86fe61f44
+CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:d8a14cf03a7872a88dd61e1aa6b2a84ce031a2044d0d4d129154041a1adaa481
 
 # cert-manager operand - webhook component image digest.
-CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
 
 # cert-manager operand - cainjector component image digest.
-CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
 
 # cert-manager operand - controller component image digest.
-CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:6f2a1b7d8a8d68ef368b0b5d1839b0589ff4eb0eb67dd70b712202ce5a7117c4
+CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
 
 # cert-manager operand - acmesolver component image digest.
-CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:4c12e931f7267c1b13fd9221bc7e79c6f0bdf44a9c9cdec65559a49a68e2ab4b
+CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9321868c6d82f1b447e27bb1066eeaa2fa0c3347087d03dced7a775bfddad32e
 
 # cert-manager-istiocsr operand image digest.
 CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c06b1de6930b1157f0cd6c68995f3857a683867681d8501d897c8b815711f7e7


### PR DESCRIPTION
## Summary
- Update staged image digests in `images_digest.conf` for cert-manager operator v1.20.0 and operand images v1.20.3
- Updated digests for operator, webhook, cainjector, controller, and acmesolver components

```
$ docker pull registry.redhat.io/cert-manager/cert-manager-operator-rhel9:v1.20.0
v1.20.0: Pulling from cert-manager/cert-manager-operator-rhel9
Digest: sha256:d8a14cf03a7872a88dd61e1aa6b2a84ce031a2044d0d4d129154041a1adaa481
Status: Downloaded newer image for registry.redhat.io/cert-manager/cert-manager-operator-rhel9:v1.20.0
registry.redhat.io/cert-manager/cert-manager-operator-rhel9:v1.20.0

```

```
$ docker pull registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9:v1.20.3
v1.20.3: Pulling from cert-manager/jetstack-cert-manager-rhel9
Digest: sha256:f3683d29aa703829fb0d0ba93711188fb717cc1ac156877c9d0ab5fb5083513f
Status: Downloaded newer image for registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9:v1.20.3
registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9:v1.20.3
```

```
$ docker pull registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9:v1.20.3
v1.20.3: Pulling from cert-manager/jetstack-cert-manager-acmesolver-rhel9
Digest: sha256:9321868c6d82f1b447e27bb1066eeaa2fa0c3347087d03dced7a775bfddad32e
Status: Downloaded newer image for registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9:v1.20.3
registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9:v1.20.3
```

```
$ docker pull registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9:v0.16.0-2
v0.16.0-2: Pulling from cert-manager/cert-manager-istio-csr-rhel9
8af57f051b37: Already exists 
7ef25e0867a8: Pull complete 
Digest: sha256:a5fb3245a48f2835b52152827bef540cb2376ace53f2de61756c72d71f536d83
Status: Downloaded newer image for registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9:v0.16.0-2
registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9:v0.16.0-2
```

## Test plan
- [x] Verify `images_digest.conf` digests match pulled `registry.stage.redhat.io` images
- [x] Run bundle render/update workflow if applicable