### PR TITLE
[release-1.19] CM-1107: Updates the bundle with 1.19.1 staged images

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,22 +4,22 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # cert-manager operator image digest.
-CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
 
 # cert-manager operand - webhook component image digest.
-CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
 
 # cert-manager operand - cainjector component image digest.
-CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
 
 # cert-manager operand - controller component image digest.
-CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f0467f589027c52288f2707bab33d0ccd1c15410dcbc9010d0f948feb4e50dd0
+CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
 
 # cert-manager operand - acmesolver component image digest.
-CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:2118a138033fa32afb314d697dc29d2690277a978c8a84b1eba4f152a6d59c1a
+CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
 
 # cert-manager-istiocsr operand image digest.
-CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:65711de646434e6462387113e80cf3fdc31736369a2a2046ea56eb59643e92fb
+CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
 
 # cert-manager trust-manager operand image digest.
 CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82


### PR DESCRIPTION
The PR is for updating the bundle with the latest 1.19.1 release staged images.

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/6d8e44d7d69924100b9f10050db495137d61629a",
                    "version": "v1.19.1"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/0b681685f7a79342e4d7960e48b307c655cebcc2",
                    "version": "v1.19.6"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/0b681685f7a79342e4d7960e48b307c655cebcc2",
                    "version": "v1.19.6"
```

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/6d8e44d7d69924100b9f10050db495137d61629a",
                    "version": "v0.16.0-1"
```