### PR TITLE
CM-1107: Updates latest 1.19.1 staged bundle in 4.18-4.22 catalogs

### DIFF
--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+name: cert-manager-operator.v1.19.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.19.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+      createdAt: 2026-08-06T08:58:45
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.19.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.6](https://github.com/cert-manager/cert-manager/tree/v1.19.6), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/channel.yaml
@@ -26,6 +26,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.19.1
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.19.1'
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -146,6 +149,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.19.1
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.19.1'
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+name: cert-manager-operator.v1.19.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.19.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+      createdAt: 2026-08-06T08:58:45
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.19.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.6](https://github.com/cert-manager/cert-manager/tree/v1.19.6), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
@@ -149,6 +149,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.19.1
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.19.1'
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+name: cert-manager-operator.v1.19.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.19.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+      createdAt: 2026-08-06T08:58:45
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.19.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.6](https://github.com/cert-manager/cert-manager/tree/v1.19.6), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/channel.yaml
@@ -57,6 +57,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.19.1
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.19.1'
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+name: cert-manager-operator.v1.19.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.19.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+      createdAt: 2026-08-06T08:58:45
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.19.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.6](https://github.com/cert-manager/cert-manager/tree/v1.19.6), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/channel.yaml
@@ -28,32 +28,35 @@ package: openshift-cert-manager-operator
 schema: olm.channel
 ---
 entries:
-  - name: cert-manager-operator.v1.18.0
-    replaces: cert-manager-operator.v1.17.0
-    skipRange: '>=1.17.0 <1.18.0'
-  - name: cert-manager-operator.v1.18.1
-    replaces: cert-manager-operator.v1.18.0
-    skipRange: '>=1.18.0 <1.18.1'
-  - name: cert-manager-operator.v1.19.0
-    replaces: cert-manager-operator.v1.18.1
-    skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.18.0
+  replaces: cert-manager-operator.v1.17.0
+  skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
+- name: cert-manager-operator.v1.19.0
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.19.1
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.19.1'
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel
 ---
 entries:
-  - name: cert-manager-operator.v1.18.0
-    replaces: cert-manager-operator.v1.17.0
-    skipRange: '>=1.17.0 <1.18.0'
-  - name: cert-manager-operator.v1.18.1
-    replaces: cert-manager-operator.v1.18.0
-    skipRange: '>=1.18.0 <1.18.1'
-  - name: cert-manager-operator.v1.19.0
-    replaces: cert-manager-operator.v1.18.1
-    skipRange: '>=1.18.1 <1.19.0'
-  - name: cert-manager-operator.v1.20.0
-    replaces: cert-manager-operator.v1.19.0
-    skipRange: '>=1.19.0 <1.20.0'
+- name: cert-manager-operator.v1.18.0
+  replaces: cert-manager-operator.v1.17.0
+  skipRange: '>=1.17.0 <1.18.0'
+- name: cert-manager-operator.v1.18.1
+  replaces: cert-manager-operator.v1.18.0
+  skipRange: '>=1.18.0 <1.18.1'
+- name: cert-manager-operator.v1.19.0
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.20.0
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
 name: stable-v1.20
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,0 +1,503 @@
+---
+image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+name: cert-manager-operator.v1.19.1
+package: openshift-cert-manager-operator
+properties:
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Challenge
+    version: v1
+- type: olm.gvk
+  value:
+    group: acme.cert-manager.io
+    kind: Order
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Certificate
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: CertificateRequest
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: cert-manager.io
+    kind: Issuer
+    version: v1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: CertManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: IstioCSR
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: TrustManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: trust.cert-manager.io
+    kind: Bundle
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-cert-manager-operator
+    version: 1.19.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "metadata": {
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
+              "dnsName": "sample.dns.name",
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "key": "XXX",
+              "solver": {
+                "dns01": {
+                  "route53": {
+                    "accessKeyID": "XXX",
+                    "hostedZoneID": "XXX",
+                    "region": "us-east-1",
+                    "secretAccessKeySecretRef": {
+                      "key": "awsSecretAccessKey",
+                      "name": "aws-secret"
+                    }
+                  }
+                },
+                "selector": {
+                  "dnsNames": [
+                    "sample.dns.name"
+                  ]
+                }
+              },
+              "token": "XXX",
+              "type": "DNS-01",
+              "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/XXXXXX/XXXXX",
+              "wildcard": false
+            }
+          },
+          {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Order",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "selfsigned-ca",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "selfsigned-ca.dns.name",
+              "isCA": true,
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "ca-cluster-issuer"
+              },
+              "privateKey": {
+                "algorithm": "ECDSA",
+                "size": 256
+              },
+              "secretName": "ca-root-secret"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+              "name": "tls-cert",
+              "namespace": "default"
+            },
+            "spec": {
+              "commonName": "sample.dns.name",
+              "dnsNames": [
+                "sample.dns.name"
+              ],
+              "isCA": false,
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "secretName": "tls-cert"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "CertificateRequest",
+            "metadata": {
+              "annotations": {
+                "cert-manager.io/certificate-name": "tls-cert",
+                "cert-manager.io/certificate-revision": "1",
+                "cert-manager.io/private-key-secret-name": "tls-cert-sample"
+              },
+              "name": "tls-cert-sample",
+              "namespace": "default"
+            },
+            "spec": {
+              "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:cert-manager",
+                "system:authenticated"
+              ],
+              "issuerRef": {
+                "kind": "Issuer",
+                "name": "letsencrypt-staging"
+              },
+              "request": "XXX",
+              "username": "system:serviceaccount:cert-manager:cert-manager"
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "ClusterIssuer",
+            "metadata": {
+              "name": "ca-cluster-issuer"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "ca-issuer",
+              "namespace": "default"
+            },
+            "spec": {
+              "ca": {
+                "secretName": "ca-root-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Issuer",
+            "metadata": {
+              "name": "letsencrypt-staging",
+              "namespace": "default"
+            },
+            "spec": {
+              "acme": {
+                "email": "aos-ci-cd@redhat.com",
+                "privateKeySecretRef": {
+                  "name": "letsencrypt-staging"
+                },
+                "server": "https://acme-staging-v02.api.letsencrypt.org/directory",
+                "solvers": [
+                  {
+                    "dns01": {
+                      "route53": {
+                        "accessKeyID": "ACCESS_KEY_ID",
+                        "hostedZoneID": "HOSTED_ZONE_ID",
+                        "region": "AWS_REGION",
+                        "secretAccessKeySecretRef": {
+                          "key": "access-key",
+                          "name": "sample-aws-secret"
+                        }
+                      }
+                    },
+                    "selector": {
+                      "dnsNames": [
+                        "sample.dns.name"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "CertManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "logLevel": "Normal",
+              "managementState": "Managed"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "IstioCSR",
+            "metadata": {
+              "annotations": {
+                "kubernetes.io/description": "Resource behavior is managed through IstioCSR featuregate, which is enabled by default. Please refer to the cert-manager documentation for more information on the istio-csr feature."
+              },
+              "name": "default",
+              "namespace": "istio-csr"
+            },
+            "spec": {
+              "istioCSRConfig": {
+                "certManager": {
+                  "issuerRef": {
+                    "group": "cert-manager.io",
+                    "kind": "Issuer",
+                    "name": "istio-csr-issuer"
+                  }
+                },
+                "istio": {
+                  "namespace": "istio-system"
+                },
+                "istiodTLSConfig": {
+                  "trustDomain": "cluster.local"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "TrustManager",
+            "metadata": {
+              "name": "cluster"
+            },
+            "spec": {
+              "trustManagerConfig": {
+                "defaultCAPackage": {
+                  "policy": "Enabled"
+                },
+                "logFormat": "text",
+                "logLevel": 1,
+                "trustNamespace": "cert-manager"
+              }
+            }
+          },
+          {
+            "apiVersion": "trust.cert-manager.io/v1alpha1",
+            "kind": "Bundle",
+            "metadata": {
+              "name": "example-bundle"
+            },
+            "spec": {
+              "sources": [
+                {
+                  "useDefaultCAs": true
+                }
+              ],
+              "target": {
+                "configMap": {
+                  "key": "ca-certificates.crt"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+      createdAt: 2026-08-06T08:58:45
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      olm.skipRange: '>=1.19.0 <1.19.1'
+      operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
+        OpenShift will be removed from cert-manager-operator namespace. If your Operator
+        configured any off-cluster resources, these will continue to run and require
+        manual cleanup. All operands created by the operator will need to be manually
+        cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: cert-manager-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/cert-manager-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A Bundle is used to distribute trust bundles across a Kubernetes
+          cluster.
+        displayName: Bundle
+        kind: Bundle
+        name: bundles.trust.cert-manager.io
+        version: v1alpha1
+      - description: |-
+          A CertificateRequest is used to request a signed certificate from one of the
+          configured issuers.
+
+          All fields within the CertificateRequest's `spec` are immutable after creation.
+          A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+          condition and its `status.failureTime` field.
+
+          A CertificateRequest is a one-shot resource, meaning it represents a single
+          point in time request for a certificate and cannot be re-used.
+        displayName: CertificateRequest
+        kind: CertificateRequest
+        name: certificaterequests.cert-manager.io
+        version: v1
+      - description: |-
+          A Certificate resource should be created to ensure an up to date and signed
+          X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+          The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+        displayName: Certificate
+        kind: Certificate
+        name: certificates.cert-manager.io
+        version: v1
+      - description: CertManager is the Schema for the certmanagers API
+        displayName: CertManager
+        kind: CertManager
+        name: certmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        displayName: Challenge
+        kind: Challenge
+        name: challenges.acme.cert-manager.io
+        version: v1
+      - description: |-
+          A ClusterIssuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is similar to an Issuer, however it is cluster-scoped and therefore can
+          be referenced by resources that exist in *any* namespace, not just the same
+          namespace as the referent.
+        displayName: ClusterIssuer
+        kind: ClusterIssuer
+        name: clusterissuers.cert-manager.io
+        version: v1
+      - description: |-
+          An Issuer represents a certificate issuing authority which can be
+          referenced as part of `issuerRef` fields.
+          It is scoped to a single namespace and can therefore only be referenced by
+          resources within the same namespace.
+        displayName: Issuer
+        kind: Issuer
+        name: issuers.cert-manager.io
+        version: v1
+      - description: |-
+          IstioCSR describes the configuration and information about the managed istio-csr agent.
+          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
+
+          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+        displayName: IstioCSR
+        kind: IstioCSR
+        name: istiocsrs.operator.openshift.io
+        version: v1alpha1
+      - description: Order is a type to represent an Order with an ACME server
+        displayName: Order
+        kind: Order
+        name: orders.acme.cert-manager.io
+        version: v1
+      - description: |-
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be 'cluster' to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager is created, trust-manager is deployed in the cert-manager namespace.
+        displayName: TrustManager
+        kind: TrustManager
+        name: trustmanagers.operator.openshift.io
+        version: v1alpha1
+    description: |
+      The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.19.6](https://github.com/cert-manager/cert-manager/tree/v1.19.6), which automates certificate management.
+      For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
+    displayName: cert-manager Operator for Red Hat OpenShift
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - cert-manager
+    - cert-manager-operator
+    - cert
+    - certificates
+    - security
+    - TLS
+    - istio-csr
+    - trust-manager
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/cert-manager-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
+  name: cert-manager-trust-manager
+- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
+  name: cert-manager-istiocsr
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+  name: ""
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+  name: cert-manager-acmesolver
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-webhook
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-ca-injector
+- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+  name: cert-manager-controller
+schema: olm.bundle

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/channel.yaml
@@ -14,6 +14,9 @@ entries:
 - name: cert-manager-operator.v1.19.0
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
+- name: cert-manager-operator.v1.19.1
+  replaces: cert-manager-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.19.1'
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel


### PR DESCRIPTION
The PR is for updating the 1.19.1 staged bundle in 4.18 to 4.22 OCP catalogs.

```
$ podman inspect registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/6eee8d6952a2b282222f8097bd357538be35bedb",
                    "version": "v1.19.1"
```

```
$ make update-catalog OPERATOR_BUNDLE_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66 CATALOG_DIR=catalogs/v4.18/catalog BUNDLE_FILE_NAME=bundle-v1.19.1.yaml REPLICATE_BUNDLE_FILE_IN_CATALOGS=4.18-4.22 USE_MIGRATE_LEVEL_FLAG=yes
./hack/update_catalog.sh /home/bhb/WORKSPACE/src/github.com/openshift/cert-manager-operator-release/bin/tools/opm registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66 catalogs/v4.18/catalog bundle-v1.19.1.yaml 4.18-4.22 yes
[Thu Aug  6 03:24:51 PM IST 2026] -- INFO  -- /home/bhb/WORKSPACE/src/github.com/openshift/cert-manager-operator-release/bin/tools/opm registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66 catalogs/v4.18/catalog bundle-v1.19.1.yaml 4.18-4.22 yes
[Thu Aug  6 03:24:51 PM IST 2026] -- INFO  -- inspecting registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66 bundle image
[Thu Aug  6 03:24:53 PM IST 2026] -- INFO  -- generating catalog bundle "catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- skipping replication to source catalog "catalogs/v4.18/catalog/openshift-cert-manager-operator"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- replicating catalog bundle to "catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- validating catalog "catalogs/v4.19/catalog"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- replicating catalog bundle to "catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- validating catalog "catalogs/v4.20/catalog"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- replicating catalog bundle to "catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- validating catalog "catalogs/v4.21/catalog"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- replicating catalog bundle to "catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml"
[Thu Aug  6 03:25:44 PM IST 2026] -- INFO  -- validating catalog "catalogs/v4.22/catalog"
```