### PR TITLE
OCPBUGS-85579: Updates channels to skip v1.19.0 during upgrades

### DIFF
--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/channel.yaml
@@ -27,8 +27,11 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 - name: cert-manager-operator.v1.19.1
-  replaces: cert-manager-operator.v1.19.0
-  skipRange: '>=1.19.0 <1.19.1'
+  ## with every new v1.18 z-stream release, replaces and skipRange must be updated.
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.1'
+  skips:
+    - cert-manager-operator.v1.19.0
 name: stable-v1
 package: openshift-cert-manager-operator
 schema: olm.channel
@@ -150,8 +153,11 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 - name: cert-manager-operator.v1.19.1
-  replaces: cert-manager-operator.v1.19.0
-  skipRange: '>=1.19.0 <1.19.1'
+  ## with every new v1.18 z-stream release, replaces and skipRange must be updated.
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.1'
+  skips:
+    - cert-manager-operator.v1.19.0
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/channel.yaml
@@ -150,8 +150,11 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 - name: cert-manager-operator.v1.19.1
-  replaces: cert-manager-operator.v1.19.0
-  skipRange: '>=1.19.0 <1.19.1'
+  ## with every new v1.18 z-stream release, replaces and skipRange must be updated.
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.1'
+  skips:
+    - cert-manager-operator.v1.19.0
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/channel.yaml
@@ -58,8 +58,11 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 - name: cert-manager-operator.v1.19.1
-  replaces: cert-manager-operator.v1.19.0
-  skipRange: '>=1.19.0 <1.19.1'
+  ## with every new v1.18 z-stream release, replaces and skipRange must be updated.
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.1'
+  skips:
+    - cert-manager-operator.v1.19.0
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/channel.yaml
@@ -38,8 +38,11 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 - name: cert-manager-operator.v1.19.1
-  replaces: cert-manager-operator.v1.19.0
-  skipRange: '>=1.19.0 <1.19.1'
+  ## with every new v1.18 z-stream release, replaces and skipRange must be updated.
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.1'
+  skips:
+    - cert-manager-operator.v1.19.0
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/channel.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/channel.yaml
@@ -15,8 +15,11 @@ entries:
   replaces: cert-manager-operator.v1.18.1
   skipRange: '>=1.18.1 <1.19.0'
 - name: cert-manager-operator.v1.19.1
-  replaces: cert-manager-operator.v1.19.0
-  skipRange: '>=1.19.0 <1.19.1'
+  ## with every new v1.18 z-stream release, replaces and skipRange must be updated.
+  replaces: cert-manager-operator.v1.18.1
+  skipRange: '>=1.18.1 <1.19.1'
+  skips:
+    - cert-manager-operator.v1.19.0
 name: stable-v1.19
 package: openshift-cert-manager-operator
 schema: olm.channel


### PR DESCRIPTION
The PR is for updating the channels to skip 1.19.0 which has issue reported in OCPBUGS-85579, where the operator installation fails on console-less cluster. By skipping the operator v1.19.0, users could upgrade from lower versions without any failure directly to v1.19.1.