### PR TITLE
CM-1108: Updates the bundle with the v1.19.1 prod images

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,22 +4,22 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # cert-manager operator image digest.
-CERT_MANAGER_OPERATOR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
+CERT_MANAGER_OPERATOR_IMAGE=registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
 
 # cert-manager operand - webhook component image digest.
-CERT_MANAGER_WEBHOOK_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+CERT_MANAGER_WEBHOOK_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
 
 # cert-manager operand - cainjector component image digest.
-CERT_MANAGER_CA_INJECTOR_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+CERT_MANAGER_CA_INJECTOR_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
 
 # cert-manager operand - controller component image digest.
-CERT_MANAGER_CONTROLLER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+CERT_MANAGER_CONTROLLER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
 
 # cert-manager operand - acmesolver component image digest.
-CERT_MANAGER_ACMESOLVER_IMAGE=registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+CERT_MANAGER_ACMESOLVER_IMAGE=registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9c8b984fc9f5d792f44e11c431e9ddf23aec64af3585e9662b43fd1a4102bb2b
 
 # cert-manager-istiocsr operand image digest.
-CERT_MANAGER_ISTIOCSR_IMAGE=registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
+CERT_MANAGER_ISTIOCSR_IMAGE=registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:62e05e3dcd97963e6b9dd3985f5c3f501a628c4869c0414224fcb5530ff84885
 
 # cert-manager trust-manager operand image digest.
 CERT_MANAGER_TRUST_MANAGER_IMAGE=registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82


### PR DESCRIPTION
The PR is for the updating the v1.19.1 prod images in the operator bundle.

```
$ podman inspect registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/578f02f58e3cf1002a36fe8b00761d8c99dffeff",
                    "version": "v1.19.1"
```

```
$ podman inspect registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/578f02f58e3cf1002a36fe8b00761d8c99dffeff",
                    "version": "v1.19.6"
```

```
$ podman inspect registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9c8b984fc9f5d792f44e11c431e9ddf23aec64af3585e9662b43fd1a4102bb2b | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/578f02f58e3cf1002a36fe8b00761d8c99dffeff",
                    "version": "v1.19.6"
```

```
$ podman inspect registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:62e05e3dcd97963e6b9dd3985f5c3f501a628c4869c0414224fcb5530ff84885 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/578f02f58e3cf1002a36fe8b00761d8c99dffeff",
                    "version": "v0.16.0-1"
```