### PR TITLE
CM-1108: Updates the v1.19.1 prod bundle image in OCP 4.18-4.22 catalogs

### DIFF
--- a/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.18/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
 name: cert-manager-operator.v1.19.1
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-      createdAt: 2026-08-06T08:58:45
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+      createdAt: 2026-08-13T11:44:13
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:62e05e3dcd97963e6b9dd3985f5c3f501a628c4869c0414224fcb5530ff84885
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
-  name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9c8b984fc9f5d792f44e11c431e9ddf23aec64af3585e9662b43fd1a4102bb2b
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.19/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
 name: cert-manager-operator.v1.19.1
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-      createdAt: 2026-08-06T08:58:45
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+      createdAt: 2026-08-13T11:44:13
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:62e05e3dcd97963e6b9dd3985f5c3f501a628c4869c0414224fcb5530ff84885
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
-  name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9c8b984fc9f5d792f44e11c431e9ddf23aec64af3585e9662b43fd1a4102bb2b
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.20/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
 name: cert-manager-operator.v1.19.1
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-      createdAt: 2026-08-06T08:58:45
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+      createdAt: 2026-08-13T11:44:13
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:62e05e3dcd97963e6b9dd3985f5c3f501a628c4869c0414224fcb5530ff84885
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
-  name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9c8b984fc9f5d792f44e11c431e9ddf23aec64af3585e9662b43fd1a4102bb2b
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.21/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
 name: cert-manager-operator.v1.19.1
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-      createdAt: 2026-08-06T08:58:45
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+      createdAt: 2026-08-13T11:44:13
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:62e05e3dcd97963e6b9dd3985f5c3f501a628c4869c0414224fcb5530ff84885
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
-  name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9c8b984fc9f5d792f44e11c431e9ddf23aec64af3585e9662b43fd1a4102bb2b
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-controller
 schema: olm.bundle

--- a/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
+++ b/catalogs/v4.22/catalog/openshift-cert-manager-operator/bundle-v1.19.1.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
+image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
 name: cert-manager-operator.v1.19.1
 package: openshift-cert-manager-operator
 properties:
@@ -334,8 +334,8 @@ properties:
       capabilities: Seamless Upgrades
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-      createdAt: 2026-08-06T08:58:45
+      containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+      createdAt: 2026-08-13T11:44:13
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -484,20 +484,20 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
+- image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:62e05e3dcd97963e6b9dd3985f5c3f501a628c4869c0414224fcb5530ff84885
+  name: cert-manager-istiocsr
+- image: registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2
+  name: ""
+- image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:3c724c0ef5413b9f8c7a0635672fe5b1276374441f88e8d735204a3316d03c1d
+  name: ""
 - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
   name: cert-manager-trust-manager
-- image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:1db7aa8f10ad076b519801c50e67d643e8efbfc1da96e9daa93cda92d6935da1
-  name: cert-manager-istiocsr
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:fa0598b52fbc557d14ba4a4ff5794ff249e2afe7cff3d2ebbff7fb0b656e8c66
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:5028fc14b86fe0c93ccd19066ec88f710405e098f2f4396e2c1d4a74bfed7767
-  name: ""
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:98a6cf15d9e1e17d91b12d6b638b2c11e443415f699e3070809b78eaa6845ab1
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:9c8b984fc9f5d792f44e11c431e9ddf23aec64af3585e9662b43fd1a4102bb2b
   name: cert-manager-acmesolver
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-webhook
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-ca-injector
-- image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:5ee9038841cab5599921b77e4818b19672617364844a347fb5a8a351fb5ffd99
+- image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:7a57188bfaae2f54ef1430d4fd851f96aac27614d6ba0a4527e5efd42634add5
   name: cert-manager-controller
 schema: olm.bundle


### PR DESCRIPTION
The PR is for updating the prod bundle image of v1.19.1 in 4.18 to 4.22 OCP catalogs.

```
$ podman inspect registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9d49df1bb6956c8ae8197b882cf879feb5b888197fe9529c09bb924be8d48eb2 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/cert-manager-operator-release/commit/7efc97ad65bd83a9388ba01d27a4832679c5a2e7",
                    "version": "v1.19.1"
```