### PR TITLE
NO-JIRA: Updates the 5.0 catalog Containerfile to use new base image

### DIFF
--- a/Containerfile.catalog
+++ b/Containerfile.catalog
@@ -1,1 +1,1 @@
-./catalogs/v4.21/Containerfile
+./catalogs/v5.0/Containerfile

--- a/catalog
+++ b/catalog
@@ -1,1 +1,1 @@
-./catalogs/v4.21/catalog
+./catalogs/v5.0/catalog

--- a/catalogs/v5.0/Containerfile
+++ b/catalogs/v5.0/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0
+FROM registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
The PR is for updating the base image used in OCP v5.0 catalog Containerfile to the image from `openshift5` namespace.